### PR TITLE
refactor(pg-pubsub): improve queue management, reliability, and transaction support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,17 @@ name: CI
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
+    inputs:
+      run_stress_tests:
+        description: "Run stress tests"
+        required: false
+        type: boolean
+        default: false
 
 env:
   NODE_VERSION: 22
@@ -21,12 +27,12 @@ env:
 
 jobs:
   prepare:
-      name: Prepare
-      runs-on: ubuntu-latest
-      steps:
-        - uses: DerYeger/yarn-setup-action@master
-          with:
-            node-version: ${{ env.NODE_VERSION }}
+    name: Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: DerYeger/yarn-setup-action@master
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
   build:
     name: Build
@@ -115,3 +121,57 @@ jobs:
         with:
           files: ./coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  stress-test:
+    name: Stress Test
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_stress_tests }}
+    timeout-minutes: 5
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: ${{ env.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ env.POSTGRES_DB }}
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: DerYeger/yarn-setup-action@master
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Create .env file
+        run: |
+          echo "POSTGRES_USER=${{ env.POSTGRES_USER }}" > .env
+          echo "POSTGRES_PASSWORD=${{ env.POSTGRES_PASSWORD }}" >> .env
+          echo "POSTGRES_DB=${{ env.POSTGRES_DB }}" >> .env
+          echo "POSTGRES_HOST=${{ env.POSTGRES_HOST }}" >> .env
+          echo "POSTGRES_PORT=${{ env.POSTGRES_PORT }}" >> .env
+          echo "REDIS_HOST=${{ env.REDIS_HOST }}" >> .env
+          echo "REDIS_PORT=${{ env.REDIS_PORT }}" >> .env
+          echo "DATABASE_URL=postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@${{ env.POSTGRES_HOST }}:${{ env.POSTGRES_PORT }}/${{ env.POSTGRES_DB }}" >> .env
+
+      - name: Run stress tests
+        env:
+          STRESS_MESSAGE_COUNT: "500"
+          STRESS_BATCH_SIZE: "50"
+          STRESS_TIMEOUT_MS: "120000"
+        run: yarn test:stress

--- a/apps/app/src/assets/docs/pg-pubsub/advanced-usage.md
+++ b/apps/app/src/assets/docs/pg-pubsub/advanced-usage.md
@@ -1,328 +1,81 @@
 # Advanced Usage
 
-## Module Configuration Options
+## Configuration Reference
 
-The library provides configuration options to customize its behavior. You can pass an optional configuration object when initializing the PgPubSubModule in your module.
+All options except `databaseUrl` are optional.
 
 ```typescript
-import { Module } from '@nestjs/common'
-import { TypeOrmModule } from '@nestjs/typeorm'
-import { PgPubSubModule } from '@cisstech/nestjs-pg-pubsub'
+PgPubSubModule.forRoot({
+  databaseUrl: process.env.DATABASE_URL,
 
-@Module({
-  imports: [
-    TypeOrmModule.forRoot({
-      /* your TypeORM config */
-    }),
-    PgPubSubModule.forRoot({
-      databaseUrl: 'postgresql://user:password@localhost:5432/dbname',
-      ssl: {
-        rejectUnauthorized: true,
-        ca: fs.readFileSync('/path/to/ca.crt').toString(),
-      },
-      triggerSchema: 'myschema', // Default: 'public'
-      triggerPrefix: 'my_trigger_prefix', // Default: 'pubsub_trigger'
-      // Optional: dedicated pool config (independent of TypeORM)
-      pool: {
-        max: 2, // Default: 2
-      },
-      queue: {
-        table: 'custom_queue_table', // Default: 'pg_pubsub_queue'
-        maxRetries: 5, // Default: 5
-        messageTTL: 24 * 60 * 60 * 1000, // Default: 24 hours
-        cleanupInterval: 60 * 60 * 1000, // Default: 1 hour
-        batchSize: 100, // Default: 100 — max messages fetched per pull cycle
-      },
-    }),
-  ],
+  ssl: { rejectUnauthorized: true, ca: '...' },
+
+  triggerPrefix: 'my_prefix', // default: 'pubsub_trigger'
+  triggerSchema: 'myschema', // default: 'public'
+
+  fallbackPollingInterval: 60_000, // ms, safety-net polling interval
+  lockDuration: 5_000, // ms, advisory lock duration for DDL setup
+
+  pool: {
+    max: 5, // dedicated pg.Pool connections (independent of TypeORM)
+  },
+
+  queue: {
+    table: 'pg_pubsub_queue',
+    batchSize: 100, // max messages per pull cycle
+    drainInterval: 50, // ms, pause between drain loop iterations
+    processingTimeout: 300_000, // ms, after this 'processing' messages are considered orphaned
+    maxRetries: 5,
+    messageTTL: 86_400_000, // ms, cleanup threshold for old messages (24h)
+    cleanupInterval: 3_600_000, // ms, how often the cleanup job runs (1h)
+  },
 })
-export class AppModule {}
 ```
 
-- **ssl**: Optional SSL configuration for secure database connections. This is passed directly to the underlying `pg-listen` library (which uses `node-postgres`). You can provide any SSL options supported by `node-postgres`, such as:
+### Key Options Explained
 
-  - `rejectUnauthorized`: Whether to reject unauthorized connections (set to `true` in production)
-  - `ca`: Certificate authority certificate(s)
-  - `key`: Client private key
-  - `cert`: Client certificate
+**`triggerPrefix`**: All triggers created by the library are named `{triggerPrefix}_{table_name}`. On startup, triggers matching this prefix that are no longer needed are dropped. Choose a unique prefix per module if you use multiple `PgPubSubModule.forRoot()` registrations.
 
-- **triggerPrefix**: Defines the prefix used for all database triggers dynamically created by the library. This is **critical** since during initialization, the library will automatically delete any existing database triggers whose names start with this prefix before creating new ones.
+**`queue.drainInterval`**: After processing a batch, the drain loop waits this long before fetching the next batch. Prevents tight-looping that could saturate the database under high throughput. Set to `0` to disable.
 
-- **triggerSchema**: The PostgreSQL schema where the tables and triggers are located.
+**`queue.processingTimeout`**: Messages are moved to `processing` while being handled. If a message stays in `processing` longer than this timeout (e.g., the process crashed), it is considered orphaned and reset to `pending` on the next startup. Must be longer than your slowest listener.
 
-- **queue.table**: Name of the queue table to store messages.
+**`pool.max`**: The library uses its own `pg.Pool` for all SQL operations (queue reads, advisory locks, trigger DDL). This pool is completely independent of TypeORM's pool, ensuring pg-pubsub keeps working even when TypeORM's pool is exhausted.
 
-- **queue.maxRetries**: Maximum number of retry attempts for failed messages.
+## Controlling the Listener at Runtime
 
-- **queue.messageTTL**: How long to keep messages before they're cleaned up (in milliseconds).
-
-- **queue.cleanupInterval**: How often to run the cleanup job (in milliseconds).
-
-- **queue.batchSize**: Maximum number of messages fetched per pull cycle (default: 100).
-
-- **pool.max**: Maximum number of connections in the dedicated pool (default: 2). This pool is independent of TypeORM's connection pool, so pg-pubsub operations are never blocked by TypeORM pool exhaustion.
-
-## Message Processing Architecture
-
-The library uses a hybrid approach to message processing for optimal performance and reliability:
-
-1. **Immediate Processing**: When a database change occurs, the trigger sends a notification with just the message ID. The service immediately pulls and processes that message.
-
-2. **Fallback Polling**: In addition, a low-frequency polling mechanism ensures that no messages are missed, even if notifications are lost or the service is temporarily down.
-
-3. **Ordered Processing**: Messages are processed in the order they were created, based on their ID.
-
-4. **Transaction Safety**: The system uses PostgreSQL advisory locks and `SELECT FOR UPDATE SKIP LOCKED` to ensure messages are processed exactly once, even in distributed environments.
-
-5. **Backpressure**: At most one pull cycle runs at a time. If new notifications arrive during processing, they are coalesced into a single re-fetch once the current cycle completes.
-
-6. **Conditional Trigger DDL**: On startup, trigger functions are fingerprinted with an MD5 hash (stored in the `pg_pubsub_trigger_meta` metadata table). Triggers are only recreated when their configuration actually changes, avoiding unnecessary DDL on every restart.
-
-## Controlling the Listener
-
-The library provides methods to control the behavior of the PostgreSQL listener at runtime:
-
-### Pause and Resume
-
-You can pause and resume the listener as needed:
+### Pause / Resume
 
 ```typescript
-import { Injectable } from '@nestjs/common'
-import { PgPubSubService } from '@cisstech/nestjs-pg-pubsub'
-
-@Injectable()
-export class ListenerControlService {
-  constructor(private readonly pgPubSubService: PgPubSubService) {}
-
-  async pauseListener(): Promise<void> {
-    await this.pgPubSubService.pause()
-  }
-
-  async resumeListener(): Promise<void> {
-    await this.pgPubSubService.resume()
-  }
-}
+await this.pgPubSubService.pause() // stop listening, stop processing notifications
+await this.pgPubSubService.resume() // reconnect and start listening again
 ```
+
+Messages inserted while paused accumulate in the queue and are processed on resume.
 
 ### Suspend and Run
 
-Sometimes you might want to temporarily suspend the listener while performing certain operations:
+Pause, execute a callback, resume (even if the callback throws):
 
 ```typescript
-import { Injectable } from '@nestjs/common'
-import { PgPubSubService } from '@cisstech/nestjs-pg-pubsub'
-
-@Injectable()
-export class DataService {
-  constructor(private readonly pgPubSubService: PgPubSubService) {}
-
-  async performBulkOperations(): Promise<void> {
-    // Suspend the listener while performing bulk operations
-    await this.pgPubSubService.suspendAndRun(async () => {
-      // Perform your operations here
-      // No events will be processed during this time
-    })
-    // Listener is automatically resumed after the callback completes
-  }
-}
+await this.pgPubSubService.suspendAndRun(async () => {
+  await this.runMigrations()
+})
 ```
 
 ### Disable Triggers for Specific Operations
 
-When performing bulk operations like cascade deletes, you may want to prevent pg-pubsub from generating notifications for rows that are being deleted as part of the cascade. Use `withTriggersDisabled` to run operations silently:
+When performing bulk operations (cascade deletes, data migrations), suppress trigger notifications with `withTriggersDisabled`. This sets `SET LOCAL pg_pubsub.disabled = 'true'` and only affects the current transaction. Other sessions are not impacted.
 
 ```typescript
-import { Injectable } from '@nestjs/common'
-import { PgPubSubService } from '@cisstech/nestjs-pg-pubsub'
-import { Customer } from './entities/customer.entity'
+// TypeORM variant: provides an EntityManager
+await this.pgPubSubService.withTriggersDisabled(async (em) => {
+  await em.getRepository(Customer).delete(customerId)
+})
 
-@Injectable()
-export class CustomerService {
-  constructor(private readonly pgPubSubService: PgPubSubService) {}
-
-  async deleteCustomerWithCascade(customerId: string): Promise<void> {
-    // Delete customer and all related entities without triggering notifications
-    await this.pgPubSubService.withTriggersDisabled(async (entityManager) => {
-      await entityManager.getRepository(Customer).delete(customerId)
-      // Orders, invoices, etc. deleted via CASCADE won't trigger notifications
-    })
-  }
-}
-```
-
-This method:
-
-- Creates a transaction with `SET LOCAL pg_pubsub.disabled = 'true'`
-- Provides a TypeORM `EntityManager` for database operations
-- Automatically commits on success, rolls back on error
-- Only affects the current transaction (other sessions are not impacted)
-
-#### Raw SQL Alternative
-
-If you prefer to work without TypeORM entities, use `withTriggersDisabledRaw`:
-
-```typescript
+// Raw SQL variant: uses the dedicated pg pool
 await this.pgPubSubService.withTriggersDisabledRaw(async (query) => {
   await query('DELETE FROM orders WHERE customer_id = $1', [customerId])
   await query('DELETE FROM customers WHERE id = $1', [customerId])
 })
-```
-
-This uses the dedicated pg pool and is independent of TypeORM.
-
-## Multiple Listeners for the Same Table
-
-You can register multiple listeners for the same table to handle different aspects of changes:
-
-```typescript
-@Injectable()
-@RegisterPgTableChangeListener(User, { events: ['INSERT'] })
-export class UserCreationListener implements PgTableChangeListener<User> {
-  async process(changes: PgTableChanges<User>): Promise<void> {
-    // Handle only new user creation
-  }
-}
-
-@Injectable()
-@RegisterPgTableChangeListener(User, { events: ['UPDATE'] })
-export class UserUpdateListener implements PgTableChangeListener<User> {
-  async process(changes: PgTableChanges<User>): Promise<void> {
-    // Handle only user updates
-  }
-}
-```
-
-The library will automatically merge the event registrations into a single PostgreSQL trigger function for optimal performance.
-
-## Selective Error Handling
-
-The library allows you to selectively mark specific messages as failed:
-
-```typescript
-@Injectable()
-@RegisterPgTableChangeListener(User)
-export class UserListener implements PgTableChangeListener<User> {
-  async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
-    // Process each message individually for fine-grained error handling
-    for (const change of changes.all) {
-      try {
-        // Process the change
-        await this.processChange(change)
-      } catch (error) {
-        // Mark only this specific message as failed
-        onError?.([change.id])
-        // Continue processing other messages
-      }
-    }
-  }
-
-  private async processChange(change: PgTableChangePayload<User>): Promise<void> {
-    // Process a single change
-  }
-}
-```
-
-## Queue Metadata for Retry Handling
-
-Each change payload includes `_metadata` with retry information. This is useful when syncing to external systems (Kafka, Redis, APIs) where stale retry data could cause issues.
-
-**Metadata fields:**
-
-- `retry_count`: Number of failures (0 = first attempt, 1 = 1st retry, etc.)
-- `created_at`: When the message was originally queued
-
-### Example: Syncing to External Systems with Retry Handling
-
-```typescript
-import { Injectable } from '@nestjs/common'
-import { InjectRepository } from '@nestjs/typeorm'
-import { Repository } from 'typeorm'
-import {
-  RegisterPgTableChangeListener,
-  PgTableChangeListener,
-  PgTableChanges,
-  PgTableChangeErrorHandler,
-} from '@cisstech/nestjs-pg-pubsub'
-import { User } from './entities/user.entity'
-
-@Injectable()
-@RegisterPgTableChangeListener(User)
-export class UserKafkaSyncListener implements PgTableChangeListener<User> {
-  constructor(
-    @InjectRepository(User) private userRepository: Repository<User>,
-    private redisCache: RedisService
-  ) {}
-
-  async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
-    for (const change of changes.all) {
-      try {
-        const retryCount = change._metadata?.retry_count ?? 0
-
-        // For retries, fetch fresh data to avoid syncing stale info
-        let userData = change.data
-        if (retryCount >= 1) {
-          const latestUser = await this.userRepository.findOne({
-            where: { id: change.data.id },
-          })
-          if (!latestUser) {
-            console.log(`User ${change.data.id} no longer exists, skipping`)
-            continue
-          }
-          userData = latestUser
-        }
-        if (retryCount < 1) {
-          await this.callExternalAPI(userData)
-        } else {
-          // Use circuit breaker or fallback for persistent failures
-          await this.sendToDeadLetterQueue(userData)
-        }
-      } catch (error) {
-        onError?.([change.id])
-      }
-    }
-  }
-
-  private async callExternalAPI(user: User): Promise<void> {
-    // Implementation...
-  }
-
-  private async sendToDeadLetterQueue(user: User): Promise<void> {
-    // Implementation...
-  }
-}
-```
-
-## Publishing Custom Events from PostgreSQL
-
-You can publish custom events directly from PostgreSQL by sending a notification:
-
-```sql
-CREATE OR REPLACE FUNCTION notify_custom_event()
-RETURNS TRIGGER AS $$
-BEGIN
-  -- Send notification with just the message ID
-  PERFORM pg_notify('custom-event', 'Hello world');
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER user_login_trigger
-  AFTER INSERT ON user_login_history
-  FOR EACH ROW
-  EXECUTE PROCEDURE notify_custom_event();
-```
-
-Then subscribe to these events in your NestJS application:
-
-```typescript
-@Injectable()
-export class AuthEventsService implements OnModuleInit {
-  constructor(private readonly pgPubSubService: PgPubSubService) {}
-
-  async onModuleInit(): Promise<void> {
-    await this.pgPubSubService.susbcribe('custom-event', (payload) => {
-      console.log(`Received notification for message:`, payload)
-    })
-  }
-}
 ```

--- a/apps/app/src/assets/docs/pg-pubsub/getting-started.md
+++ b/apps/app/src/assets/docs/pg-pubsub/getting-started.md
@@ -1,64 +1,57 @@
-# @cisstech/nestjs-pg-pubsub
+# Getting Started
 
-<div align="center">
+## What This Library Does
 
-A NestJS module for real-time PostgreSQL notifications using PubSub
+This library turns PostgreSQL into a reliable change data capture (CDC) system for NestJS. When a row is inserted, updated or deleted in a monitored table, a PostgreSQL trigger persists the change in a queue table and sends a `NOTIFY`. The library picks up that notification, pulls pending messages from the queue, and dispatches them to your typed listener classes.
 
-[![CI](https://github.com/cisstech/nestkit/actions/workflows/ci.yml/badge.svg)](https://github.com/cisstech/nestkit/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/cisstech/nestkit/branch/main/graph/badge.svg)](https://codecov.io/gh/cisstech/nestkit)
-[![codefactor](https://www.codefactor.io/repository/github/cisstech/nestkit/badge/main)](https://www.codefactor.io/repository/github/cisstech/nestkit/overview/main)
-[![GitHub Tag](https://img.shields.io/github/tag/cisstech/nestkit.svg)](https://github.com/cisstech/nestkit/tags)
-[![npm package](https://img.shields.io/npm/v/@cisstech/nestjs-pg-pubsub.svg)](https://www.npmjs.org/package/@cisstech/nestjs-pg-pubsub)
-[![NPM downloads](http://img.shields.io/npm/dm/@cisstech/nestjs-pg-pubsub.svg)](https://npmjs.org/package/@cisstech/nestjs-pg-pubsub)
-[![licence](https://img.shields.io/github/license/cisstech/nestkit)](https://github.com/cisstech/nestkit/blob/main/LICENSE)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+The result: you get real-time reactivity (via `LISTEN/NOTIFY`) with guaranteed delivery (via the persistent queue). No external broker needed.
 
-</div>
+## Architecture
 
-## Overview
+```
+┌──────────────┐     trigger      ┌──────────────────┐    NOTIFY    ┌──────────────────┐
+│  Your Table  │ ──────────────►  │  pg_pubsub_queue │ ──────────►  │  PgPubSubService │
+│  (INSERT/    │                  │  (persistent)    │              │  (pull + drain)  │
+│   UPDATE/    │                  └──────────────────┘              └────────┬─────────┘
+│   DELETE)    │                                                            │
+└──────────────┘                                                            ▼
+                                                                   ┌──────────────────┐
+                                                                   │  Your Listeners  │
+                                                                   │  (@Register...)  │
+                                                                   └──────────────────┘
+```
 
-The NestJS PG-PubSub library is a powerful tool that facilitates real-time communication between your NestJS application and PostgreSQL database using the native PostgreSQL Pub/Sub mechanism. It allows your application to listen for changes on specific database tables and respond to those changes in real-time, making it ideal for building reactive applications with immediate data synchronization and event-driven workflows.
+### Message Lifecycle
 
-## Features
+1. **Capture**: a trigger fires on the monitored table and inserts a JSON payload into `pg_pubsub_queue` with status `pending`
+2. **Notify**: the same trigger sends a `pg_notify` with the channel name
+3. **Pull**: the service receives the notification and fetches pending messages with `SELECT FOR UPDATE SKIP LOCKED`
+4. **Process**: messages are grouped by table and dispatched to matching listeners
+5. **Ack/Fail**: successful messages go to `processed`; failed ones go to `failed` with exponential retry ($2^{n}$ minutes, up to `maxRetries`)
+6. **Cleanup**: a background job periodically deletes old processed/dead messages
 
-- **Real-Time Table Change Detection**: Automatically listen for INSERT, UPDATE, and DELETE events on PostgreSQL tables
-- **Decorator-Based Configuration**: Use intuitive decorators to register table change listeners
-- **Automatic Trigger Management**: Dynamically creates and manages PostgreSQL triggers
-- **Event Buffering and Batching**: Optimizes performance by buffering and batching events
-- **Entity Mapping**: Maps database column names to entity property names automatically
-- **Persistent Message Queue**: Messages are stored in a PostgreSQL table to prevent data loss
-- **Reactive Processing**: Immediately pulls and processes messages when notifications are received
-- **TTL and Retry System**: Implements time-to-live and automatic retries for failed message processing
-- **Message Ordering**: Preserves message processing order using row IDs
-- **Auto Cleanup**: Automatically removes old processed messages to keep the queue size manageable
-- **Multiple Subscribers**: Leverages PostgreSQL's native Pub/Sub to allow multiple application instances to subscribe to the same changes
-- **Error Handling**: Provides comprehensive error handling mechanisms
-- **Fallback Reliability**: Includes low-frequency background polling to ensure no messages are missed
-- **Dedicated Connection Pool**: Uses its own `pg.Pool`, independent of TypeORM, to avoid pool contention
-- **Backpressure**: Concurrent notifications are coalesced so at most one pull cycle runs at a time
-- **Smart Trigger Management**: Triggers are only recreated when their configuration actually changes
+### Safety Nets
 
-## Technical Architecture
+- **Fallback poller**: runs every `fallbackPollingInterval` (default 60s) to catch anything missed by `NOTIFY`
+- **Orphan recovery**: on startup, messages stuck in `processing` past their `processingTimeout` are reset to `pending`
+- **Backpressure**: concurrent notifications are coalesced so that at most one pull cycle runs at a time
+- **Trigger fingerprinting**: trigger DDL is hashed (MD5) and only recreated when config changes
 
-The library uses a hybrid architecture for optimal performance and reliability:
+### Important Constraints
 
-1. **Trigger-Based Detection**: PostgreSQL triggers capture table changes and store them in a queue table
-2. **Notification System**: Immediate notifications with message IDs are sent via PostgreSQL's NOTIFY
-3. **Message Queue**: Durable storage of change events in a queue table with status tracking
-4. **Hybrid Processing**:
-   - Reactive processing triggered by notifications
-   - Fallback polling for maximum reliability
-5. **Smart Batching**: Messages are processed in efficient batches while preserving order
-6. **Dedicated Pool**: All SQL operations run on an independent `pg.Pool`, decoupled from TypeORM
-7. **Backpressure**: Overlapping notifications are coalesced into a single re-fetch after the current cycle
-8. **Conditional DDL**: Trigger functions are fingerprinted with an MD5 hash (stored in `pg_pubsub_trigger_meta`) and only recreated when changed
+- **Do not open transactions inside listeners.** The listener runs inside the drain loop. A slow transaction blocks processing and can cause the `processingTimeout` to expire, leading to orphan recovery and duplicate processing.
+- **Keep listeners fast.** If you need heavy work, enqueue to an external job queue (Bull, etc.) from the listener.
+
+## Prerequisites
+
+- NestJS v10+ or v11+
+- PostgreSQL database
+- TypeORM configured in your application
 
 ## Additional Resources
 
-For more information about PostgreSQL's LISTEN/NOTIFY mechanism:
-
-- [PostgreSQL Documentation on NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html)
-- [PostgreSQL Documentation on LISTEN](https://www.postgresql.org/docs/current/sql-listen.html)
+- [PostgreSQL NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html)
+- [PostgreSQL LISTEN](https://www.postgresql.org/docs/current/sql-listen.html)
 
 ## License
 

--- a/apps/app/src/assets/docs/pg-pubsub/installation.md
+++ b/apps/app/src/assets/docs/pg-pubsub/installation.md
@@ -2,34 +2,20 @@
 
 ## Prerequisites
 
-Before installing the library, make sure you have:
+- NestJS v10+ or v11+
+- PostgreSQL database
+- TypeORM installed and configured
 
-- NestJS application set up
-- PostgreSQL database configured
-- TypeORM installed and configured in your application
-
-### NestJS Version Compatibility
-
-This library supports both **NestJS v10** and **NestJS v11**:
-
-- ✅ NestJS v10.x
-- ✅ NestJS v11.x
-- ✅ Node.js v18+ (v20+ recommended for NestJS v11)
-
-## Install the Package
+## Install
 
 ```bash
-yarn add @cisstech/nestjs-pg-pubsub
+yarn add @cisstech/nestjs-pg-pubsub pg
 ```
 
-Or using npm:
+Or with npm:
 
 ```bash
-npm install @cisstech/nestjs-pg-pubsub
+npm install @cisstech/nestjs-pg-pubsub pg
 ```
 
-`pg` (node-postgres) is a peer dependency — install it if you don't already have it:
-
-```bash
-yarn add pg
-```
+`pg` is a peer dependency. Skip it if you already have it.

--- a/apps/app/src/assets/docs/pg-pubsub/sample-application.md
+++ b/apps/app/src/assets/docs/pg-pubsub/sample-application.md
@@ -1,108 +1,70 @@
 # Sample Application
 
-The repository includes a complete sample application demonstrating real-time notification functionality using the PgPubSub library. This sample shows how to build a notification system that automatically pushes updates to connected clients when database changes occur.
+The repository includes a working sample at `apps/app/src/app/samples/pubsub/` that wires together:
 
-## Sample Architecture
+- Two TypeORM entities (`User`, `Notification`)
+- A `PgTableChangeListener` that reacts to notification inserts/updates/deletes
+- A Socket.IO WebSocket gateway that pushes changes to connected clients in real-time
+- REST controllers for CRUD operations
 
-The sample application consists of:
+## Running It
 
-- **Entities**: User and Notification models
-- **Services**: Business logic for users and notifications
-- **Controllers**: REST API endpoints
-- **Listeners**: PgPubSub listeners to reacts to database changes and sends notifications
-- **Gateway**: WebSocket gateway for real-time communication
-- **Module**: Wiring everything together with proper configuration
+1. Start PostgreSQL and Redis:
 
-## Entity Definitions
-
-### User Entity
-
-```typescript
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
-import { Notification } from './notification.entity'
-
-@Entity('pgpubsub_users')
-export class User {
-  @PrimaryGeneratedColumn('uuid')
-  id: string
-
-  @Column()
-  name: string
-
-  @Column({ unique: true })
-  email: string
-
-  @OneToMany(() => Notification, (notification) => notification.user)
-  notifications: Notification[]
-}
+```bash
+docker-compose up -d
 ```
 
-### Notification Entity
+2. Create a `.env` file:
 
-```typescript
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
-import { User } from './user.entity'
-
-export enum NotificationType {
-  INFO = 'info',
-  WARNING = 'warning',
-  ERROR = 'error',
-}
-
-@Entity('pgpubsub_notifications')
-export class Notification {
-  @PrimaryGeneratedColumn('uuid')
-  id: string
-
-  @Column()
-  title: string
-
-  @Column({ type: 'text' })
-  content: string
-
-  @Column({
-    type: 'enum',
-    enum: NotificationType,
-    default: NotificationType.INFO,
-  })
-  type: NotificationType
-
-  @Column({ default: false })
-  read: boolean
-
-  @CreateDateColumn()
-  createdAt: Date
-
-  @ManyToOne(() => User, (user) => user.notifications)
-  user: User
-
-  @Column()
-  userId: string
-}
+```env
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/your_database
+REDIS_HOST=localhost
+REDIS_PORT=6379
 ```
 
-## PgPubSub Table Change Listener
+3. Start the API:
+
+```bash
+yarn nx run api:serve
+```
+
+4. The API is available at `http://localhost:3000/api/v1`
+
+## Testing
+
+Use the REST Client file at `samples/demo/requests.http` to create users and notifications via the API. Changes are automatically pushed to connected WebSocket clients.
+
+Connect a WebSocket client:
+
+```javascript
+import { io } from 'socket.io-client'
+
+const socket = io('http://localhost:3000/notifications', {
+  query: { userId: 'USER_ID' },
+})
+
+socket.on('new-notification', (data) => console.log('new:', data))
+socket.on('notification-status-changed', (data) => console.log('updated:', data))
+socket.on('notification-deleted', (data) => console.log('deleted:', data))
+```
+
+Or run the included client: `node apps/api/src/app/samples/pubsub/demo/client-demo.js`
+
+## How the Listener Works
+
+The key piece is `NotificationChangeListener`:
 
 ```typescript
-import { Injectable, Logger } from '@nestjs/common'
-import { PgTableChangeListener, PgTableChanges, RegisterPgTableChangeListener } from '@cisstech/nestjs-pg-pubsub'
-import { Notification } from '../entities/notification.entity'
-import { WebsocketGateway } from '../gateways/websocket.gateway'
-
 @Injectable()
 @RegisterPgTableChangeListener(Notification, {
   events: ['INSERT', 'UPDATE', 'DELETE'],
   payloadFields: ['id', 'title', 'type', 'read', 'userId'],
 })
 export class NotificationChangeListener implements PgTableChangeListener<Notification> {
-  private readonly logger = new Logger(NotificationChangeListener.name)
-
   constructor(private readonly websocketGateway: WebsocketGateway) {}
 
   async process(changes: PgTableChanges<Notification>): Promise<void> {
-    this.logger.log(`Processing ${changes.all.length} notification changes`)
-
-    // Handle new notifications
     for (const insert of changes.INSERT) {
       this.websocketGateway.notifyUser(insert.data.userId, 'new-notification', {
         id: insert.data.id,
@@ -111,7 +73,6 @@ export class NotificationChangeListener implements PgTableChangeListener<Notific
       })
     }
 
-    // Handle status changes (read/unread)
     for (const update of changes.UPDATE) {
       if (update.data.updatedFields.includes('read')) {
         this.websocketGateway.notifyUser(update.data.new.userId, 'notification-status-changed', {
@@ -121,7 +82,6 @@ export class NotificationChangeListener implements PgTableChangeListener<Notific
       }
     }
 
-    // Handle deleted notifications
     for (const deletion of changes.DELETE) {
       this.websocketGateway.notifyUser(deletion.data.userId, 'notification-deleted', { id: deletion.data.id })
     }
@@ -129,191 +89,4 @@ export class NotificationChangeListener implements PgTableChangeListener<Notific
 }
 ```
 
-## WebSocket Gateway
-
-```typescript
-import { Injectable } from '@nestjs/common'
-import {
-  WebSocketGateway as NestWebSocketGateway,
-  WebSocketServer,
-  OnGatewayConnection,
-  OnGatewayDisconnect,
-} from '@nestjs/websockets'
-import { Server, Socket } from 'socket.io'
-
-@Injectable()
-@NestWebSocketGateway({ namespace: 'notifications' })
-export class WebsocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
-  @WebSocketServer()
-  private server: Server
-
-  private userSockets = new Map<string, string[]>()
-
-  handleConnection(client: Socket): void {
-    const userId = client.handshake.query['userId'] as string
-    if (!userId) {
-      client.disconnect()
-      return
-    }
-
-    // Store the connection
-    const userConnections = this.userSockets.get(userId) || []
-    userConnections.push(client.id)
-    this.userSockets.set(userId, userConnections)
-  }
-
-  handleDisconnect(client: Socket): void {
-    // Clean up connection from map
-    for (const [userId, sockets] of this.userSockets.entries()) {
-      const updatedSockets = sockets.filter((id) => id !== client.id)
-      if (updatedSockets.length === 0) {
-        this.userSockets.delete(userId)
-      } else {
-        this.userSockets.set(userId, updatedSockets)
-      }
-    }
-  }
-
-  notifyUser(userId: string, eventName: string, data: unknown): void {
-    const userSocketIds = this.userSockets.get(userId)
-    if (userSocketIds && userSocketIds.length) {
-      for (const socketId of userSocketIds) {
-        this.server.to(socketId).emit(eventName, data)
-      }
-    }
-  }
-}
-```
-
-## Module Configuration
-
-```typescript
-import { Module } from '@nestjs/common'
-import { TypeOrmModule } from '@nestjs/typeorm'
-import { PgPubSubModule } from '@cisstech/nestjs-pg-pubsub'
-import { User } from './entities/user.entity'
-import { Notification } from './entities/notification.entity'
-import { UserService } from './services/user.service'
-import { NotificationService } from './services/notification.service'
-import { UserController } from './controllers/user.controller'
-import { NotificationController } from './controllers/notification.controller'
-import { NotificationChangeListener } from './listeners/notification-change.listener'
-import { WebsocketGateway } from './gateways/websocket.gateway'
-
-@Module({
-  imports: [
-    TypeOrmModule.forFeature([User, Notification]),
-    PgPubSubModule.forRoot({
-      databaseUrl: process.env['DATABASE_URL']!,
-    }),
-  ],
-  controllers: [UserController, NotificationController],
-  providers: [UserService, NotificationService, WebsocketGateway, NotificationChangeListener],
-})
-export class PubSubSampleModule {}
-```
-
-## Running the Sample
-
-The sample application can be run using Docker Compose:
-
-1. Make sure you have Docker and Docker Compose installed
-2. Create a `.env` file in the root of the project:
-
-```env
-# PostgreSQL
-POSTGRES_HOST=localhost
-POSTGRES_PORT=5432
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=your_database
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/your_database
-
-# Redis (for distributed lock service)
-REDIS_HOST=localhost
-REDIS_PORT=6379
-```
-
-3. Start the containers:
-
-```bash
-docker-compose up -d
-```
-
-4. Run the application:
-
-   ```bash
-   yarn nx run api:serve
-   ```
-
-5. The API will be available at <http://localhost:3000/api/v1>
-
-## Testing with HTTP Requests
-
-The repository includes a `.http` (at samples/demo/requests.http) file for testing the API with the REST Client extension for VS Code:
-
-```http
-@baseUrl = http://localhost:3000/api/v1
-@userIdOne = {{createUser.response.body.id}}
-@userIdTwo = {{createSecondUser.response.body.id}}
-@notificationIdOne = {{createNotification.response.body.id}}
-
-### Create first user
-# @name createUser
-POST {{baseUrl}}/users HTTP/1.1
-Content-Type: application/json
-
-{
-  "name": "John Doe",
-  "email": "john.doe@example.com"
-}
-
-### Create notification for first user
-# @name createNotification
-POST {{baseUrl}}/notifications HTTP/1.1
-Content-Type: application/json
-
-{
-  "title": "Welcome!",
-  "content": "Welcome to our platform, John!",
-  "userId": "{{userIdOne}}",
-  "type": "info"
-}
-
-### Mark notification as read
-# This will trigger an UPDATE event
-PUT {{baseUrl}}/notifications/{{notificationIdOne}}/read HTTP/1.1
-```
-
-## Client-Side WebSocket Integration
-
-To integrate with the notification system from a client application:
-
-```javascript
-import { io } from 'socket.io-client'
-
-// Connect to WebSocket server
-const socket = io('http://localhost:3000/notifications', {
-  query: { userId: 'USER_ID_HERE' },
-})
-
-// Listen for notification events
-socket.on('new-notification', (notification) => {
-  console.log('New notification received:', notification)
-  // Update your UI here
-})
-
-socket.on('notification-status-changed', (data) => {
-  console.log('Notification status changed:', data)
-  // Update the read status in your UI
-})
-
-socket.on('notification-deleted', (data) => {
-  console.log('Notification was deleted:', data)
-  // Remove the notification from your UI
-})
-```
-
-Run the socket client with `node apps/api/src/app/samples/pubsub/demo/client-demo.js`
-
-This sample demonstrates how to build a complete real-time notification system using PgPubSub, WebSockets, and PostgreSQL.
+Note how the listener stays fast: it just dispatches to the WebSocket gateway without any DB writes or transactions. See [Usage > Important Constraints](./getting-started#important-constraints) for why this matters.

--- a/apps/app/src/assets/docs/pg-pubsub/usage.md
+++ b/apps/app/src/assets/docs/pg-pubsub/usage.md
@@ -1,201 +1,124 @@
 # Usage
 
-## 1. Module Registration
-
-First, register the PgPubSub module in your application:
+## Module Registration
 
 ```typescript
 import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { PgPubSubModule } from '@cisstech/nestjs-pg-pubsub'
+import { UserChangeListener } from './listeners/user-change.listener'
 
 @Module({
   imports: [
     TypeOrmModule.forRoot({
-      /* your TypeORM config */
+      /* ... */
     }),
-    PgPubSubModule.forRoot({
-      databaseUrl: 'postgresql://user:password@localhost:5432/dbname',
-      // Optional: SSL configuration for secure connections
-      ssl: {
-        rejectUnauthorized: false,
-      },
-      // Optional: dedicated pool config (independent of TypeORM)
-      pool: {
-        max: 2, // Default: 2
-      },
-      // Optional queue configuration
-      queue: {
-        maxRetries: 5, // Default: 5
-        messageTTL: 24 * 60 * 60 * 1000, // Default: 24 hours
-        cleanupInterval: 60 * 60 * 1000, // Default: 1 hour
-        batchSize: 100, // Default: 100 — max messages per pull cycle
-        table: 'pg_pubsub_queue', // Default: 'pg_pubsub_queue'
-      },
-    }),
-  ],
-})
-export class AppModule {}
-```
-
-## 2. Define Your Entities
-
-Create TypeORM entities for the tables you want to monitor:
-
-```typescript
-// user.entity.ts
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
-
-@Entity('users')
-export class User {
-  @PrimaryGeneratedColumn('uuid')
-  id: string
-
-  @Column()
-  name: string
-
-  @Column({ unique: true })
-  email: string
-}
-```
-
-## 3. Create Table Change Listeners
-
-Create classes that implement the `PgTableChangeListener` interface and decorate them with `@RegisterPgTableChangeListener`:
-
-```typescript
-import { Injectable } from '@nestjs/common'
-import {
-  RegisterPgTableChangeListener,
-  PgTableChangeListener,
-  PgTableChanges,
-  PgTableChangeErrorHandler,
-} from '@cisstech/nestjs-pg-pubsub'
-import { User } from './entities/user.entity'
-
-@Injectable()
-@RegisterPgTableChangeListener(User)
-export class UserTableChangeListener implements PgTableChangeListener<User> {
-  async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
-    try {
-      // Process all changes
-      changes.all.forEach((change) => {
-        console.log(`Change type: ${change.event} for user with id: ${change.data.id}`)
-
-        // Access metadata for retry information
-        if (change._metadata) {
-          console.log(`Retry count: ${change._metadata.retry_count}`)
-          console.log(`Created at: ${change._metadata.created_at}`)
-        }
-      })
-
-      // Process inserts
-      changes.INSERT.forEach((insert) => {
-        console.log(`New user created: ${insert.data.email}`)
-      })
-
-      // Process updates
-      changes.UPDATE.forEach((update) => {
-        console.log(`User updated: ${update.data.new.email} (was: ${update.data.old.email})`)
-        console.log(`Updated fields: ${update.data.updatedFields.join(', ')}`)
-      })
-
-      // Process deletes
-      changes.DELETE.forEach((deletion) => {
-        console.log(`User deleted: ${deletion.data.email}`)
-      })
-    } catch (error) {
-      // Mark specific messages as failed to be retried later
-      // Each change has an 'id' property that can be used for this purpose
-      if (onError) {
-        const failedIds = changes.all.map((change) => change.id)
-        onError(failedIds)
-      }
-      throw error
-    }
-  }
-}
-```
-
-## 4. Register Your Listeners
-
-Make sure to provide your listener in your module:
-
-```typescript
-import { Module } from '@nestjs/common'
-import { TypeOrmModule } from '@nestjs/typeorm'
-import { PgPubSubModule } from '@cisstech/nestjs-pg-pubsub'
-import { User } from './entities/user.entity'
-import { UserTableChangeListener } from './listeners/user-table-change.listener'
-
-@Module({
-  imports: [
-    TypeOrmModule.forFeature([User]),
     PgPubSubModule.forRoot({
       databaseUrl: process.env.DATABASE_URL,
     }),
   ],
-  providers: [UserTableChangeListener],
+  providers: [UserChangeListener],
 })
-export class UserModule {}
+export class AppModule {}
 ```
 
-## 5. Customizing Your Listeners
+That's all. The library creates the queue table and triggers on startup.
 
-You can customize what events to listen for and which fields to include in the payload:
+## Listening to Table Changes
+
+Decorate a class with `@RegisterPgTableChangeListener` and implement `PgTableChangeListener<T>`:
 
 ```typescript
 @Injectable()
-@RegisterPgTableChangeListener(User, {
-  events: ['INSERT', 'UPDATE'], // Only listen for INSERT and UPDATE events
-  payloadFields: ['id', 'email'], // Only include id and email in the payload
-})
-export class UserTableChangeListener implements PgTableChangeListener<User> {
-  // Implementation...
-}
-```
-
-## 6. Error Handling
-
-The library provides comprehensive error handling:
-
-```typescript
-async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
-  try {
-    // Process changes...
-
-    // If you need to mark specific messages as failed:
-    if (someCondition && onError) {
-      // Mark specific messages for retry
-      onError([changes.all[0].id, changes.all[1].id]);
-      return; // Exit early, no need to throw
+@RegisterPgTableChangeListener(User)
+export class UserChangeListener implements PgTableChangeListener<User> {
+  async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
+    for (const insert of changes.INSERT) {
+      console.log(`New user: ${insert.data.email}`)
     }
 
-    // Continue processing...
-  } catch (error) {
-    // For unhandled errors, mark all messages as failed
-    if (onError) {
-      onError(changes.all.map(change => change.id));
+    for (const update of changes.UPDATE) {
+      console.log(`Updated: ${update.data.updatedFields.join(', ')}`)
+      // update.data.old and update.data.new are available
+    }
+
+    for (const deletion of changes.DELETE) {
+      console.log(`Deleted: ${deletion.data.email}`)
     }
   }
 }
 ```
 
-## 7. Subscribe to Custom Events
-
-Besides table changes, you can also subscribe to custom PostgreSQL notification events:
+### Filtering Events and Fields
 
 ```typescript
-import { Injectable, OnModuleInit } from '@nestjs/common'
-import { PgPubSubService } from '@cisstech/nestjs-pg-pubsub'
+@RegisterPgTableChangeListener(User, {
+  events: ['INSERT', 'UPDATE'],     // only these events (default: all)
+  payloadFields: ['id', 'email'],   // only these columns in the payload (default: all)
+})
+```
 
+### Error Handling
+
+Use `onError` to mark specific messages as failed. They will be retried with exponential backoff.
+
+```typescript
+async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
+  for (const change of changes.all) {
+    try {
+      await this.doSomething(change)
+    } catch {
+      onError?.([change.id])  // this message will be retried
+    }
+  }
+}
+```
+
+If the entire `process()` method throws without calling `onError`, all messages in the batch are marked as failed.
+
+### Retry Metadata
+
+Each payload carries `_metadata` with `retry_count` (0 on first attempt) and `created_at`. This is useful when syncing to external systems: on retry, fetch fresh data from the DB instead of using the potentially stale payload:
+
+```typescript
+const retryCount = change._metadata?.retry_count ?? 0
+if (retryCount >= 1) {
+  const fresh = await this.userRepo.findOneBy({ id: change.data.id })
+  if (!fresh) return // deleted since, skip
+  await this.syncToExternalSystem(fresh)
+} else {
+  await this.syncToExternalSystem(change.data)
+}
+```
+
+## Multiple Listeners per Table
+
+Multiple listeners on the same table are supported. The library merges their event registrations into a single trigger:
+
+```typescript
+@RegisterPgTableChangeListener(User, { events: ['INSERT'] })
+export class UserCreationListener implements PgTableChangeListener<User> {
+  /* ... */
+}
+
+@RegisterPgTableChangeListener(User, { events: ['UPDATE'] })
+export class UserUpdateListener implements PgTableChangeListener<User> {
+  /* ... */
+}
+```
+
+## Custom NOTIFY Subscriptions
+
+You can also subscribe to arbitrary PostgreSQL `NOTIFY` channels (unrelated to table triggers):
+
+```typescript
 @Injectable()
 export class CustomEventService implements OnModuleInit {
   constructor(private readonly pgPubSubService: PgPubSubService) {}
 
   async onModuleInit(): Promise<void> {
-    await this.pgPubSubService.susbcribe<{ userId: string; action: string }>('custom-event', (payload) => {
-      console.log(`Custom event received for user ${payload.userId}: ${payload.action}`)
+    await this.pgPubSubService.susbcribe<{ action: string }>('my-channel', (payload) => {
+      console.log(payload.action)
     })
   }
 }

--- a/libs/pg-pubsub/README.md
+++ b/libs/pg-pubsub/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-A NestJS module for real-time PostgreSQL notifications using PubSub
+A NestJS module for real-time PostgreSQL change data capture using triggers and a persistent queue.
 
 [![CI](https://github.com/cisstech/nestkit/actions/workflows/ci.yml/badge.svg)](https://github.com/cisstech/nestkit/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/cisstech/nestkit/branch/main/graph/badge.svg)](https://codecov.io/gh/cisstech/nestkit)
@@ -15,256 +15,101 @@ A NestJS module for real-time PostgreSQL notifications using PubSub
 
 </div>
 
-## Overview
+## What It Does
 
-The NestJS PG-PubSub library is a powerful tool that facilitates real-time communication between your NestJS application and PostgreSQL database using the native PostgreSQL Pub/Sub mechanism. It allows your application to listen for changes on specific database tables and respond to those changes in real-time, making it ideal for building reactive applications with immediate data synchronization and event-driven workflows.
+PostgreSQL triggers detect INSERTs, UPDATEs and DELETEs on your tables. Changes are persisted in a queue table, then pulled and dispatched to typed NestJS listeners. No polling-only design, no lost messages, no external broker.
 
 ![Diagram](./mermaid.png)
 
-## Features
+## Why This Exists
 
-- **Real-Time Table Change Detection**: Automatically listen for INSERT, UPDATE, and DELETE events on PostgreSQL tables
-- **Decorator-Based Configuration**: Use intuitive decorators to register table change listeners
-- **Automatic Trigger Management**: Dynamically creates and manages PostgreSQL triggers
-- **Event Buffering and Batching**: Optimizes performance by buffering and batching events
-- **Entity Mapping**: Maps database column names to entity property names automatically
-- **Persistent Message Queue**: Messages are stored in a PostgreSQL table to prevent data loss
-- **Reactive Processing**: Immediately pulls and processes messages when notifications are received
-- **TTL and Retry System**: Implements time-to-live and automatic retries for failed message processing
-- **Queue Metadata**: Exposes retry count and creation timestamp to prevent stale data operations
-- **Message Ordering**: Preserves message processing order using row IDs
-- **Error Handling**: Provides mechanisms to handle and retry failed messages
-- **Auto Cleanup**: Automatically removes old processed messages to keep the queue size manageable
-- **Multiple Subscribers**: Leverages PostgreSQL's native Pub/Sub to allow multiple instances of your application to subscribe to the same database events
-- **Fallback Reliability**: Includes low-frequency background polling to ensure no messages are missed
-- **Dedicated Connection Pool**: Uses its own `pg.Pool`, independent of TypeORM, to avoid pool contention
-- **Backpressure**: Concurrent notifications are coalesced so at most one pull cycle runs at a time
-- **Smart Trigger Management**: Triggers are only recreated when their configuration actually changes
+PostgreSQL's `LISTEN/NOTIFY` is great for real-time but unreliable: notifications are fire-and-forget, lost during disconnects, and have a payload size limit. This library wraps it with a durable queue so you get both reactivity and guaranteed delivery.
+
+## Key Properties
+
+- **Durable**: changes are persisted in a SQL table before notification, surviving crashes and restarts
+- **Reactive**: `LISTEN/NOTIFY` triggers immediate processing, with a fallback poller as safety net
+- **Ordered**: messages are processed by ID, in batches, with `SELECT FOR UPDATE SKIP LOCKED`
+- **Retry with backoff**: failed messages are retried with exponential backoff ($2^{n}$ minutes)
+- **Backpressure**: concurrent notifications are coalesced so that at most one pull cycle runs at a time
+- **Isolated pool**: uses its own `pg.Pool`, independent of TypeORM, to avoid pool contention
+- **Zero-downtime DDL**: triggers are fingerprinted (MD5) and only recreated when config changes
 
 ## Installation
 
 ```bash
-yarn add @cisstech/nestjs-pg-pubsub
+yarn add @cisstech/nestjs-pg-pubsub pg
 ```
 
-`pg` (node-postgres) is a peer dependency - install it if you don't already have it:
+Supports NestJS v10+ and v11+.
 
-```bash
-yarn add pg
-```
-
-### NestJS Version Compatibility
-
-This library supports both **NestJS v10** and **NestJS v11**:
-
-- ✅ NestJS v10.x
-- ✅ NestJS v11.x
-
-## Usage
-
-### 1. Register the Module
+## Quick Start
 
 ```typescript
 // app.module.ts
-import { Module } from '@nestjs/common'
-import { TypeOrmModule } from '@nestjs/typeorm'
-import { PgPubSubModule } from '@cisstech/nestjs-pg-pubsub'
-import { UserTableChangeListener } from './user-change.listener'
-
 @Module({
   imports: [
     TypeOrmModule.forRoot({
-      /* your TypeORM config */
+      /* ... */
     }),
     PgPubSubModule.forRoot({
-      databaseUrl: 'postgresql://user:password@localhost:5432/dbname',
-      // Optional: SSL configuration for secure connections
-      ssl: {
-        rejectUnauthorized: false,
-      },
-      // Optional: dedicated pool config (independent of TypeORM)
-      pool: {
-        max: 2, // default
-      },
-      // Optional queue configuration
-      queue: {
-        maxRetries: 5,
-        messageTTL: 24 * 60 * 60 * 1000, // 24 hours
-        cleanupInterval: 60 * 60 * 1000, // 1 hour
-        batchSize: 100, // max messages fetched per pull cycle
-        table: 'pg_pubsub_queue',
-      },
+      databaseUrl: process.env.DATABASE_URL,
     }),
   ],
-  providers: [UserTableChangeListener],
+  providers: [UserChangeListener],
 })
 export class AppModule {}
 ```
 
-### 2. Create Table Change Listeners
-
-Create a class that implements the `PgTableChangeListener<T>` interface and decorate it with `@RegisterPgTableChangeListener`:
-
 ```typescript
-import { Injectable } from '@nestjs/common'
-import {
-  RegisterPgTableChangeListener,
-  PgTableChangeListener,
-  PgTableChanges,
-  PgTableChangeErrorHandler,
-} from '@cisstech/nestjs-pg-pubsub'
-import { User } from './entities/user.entity'
-
+// user-change.listener.ts
 @Injectable()
-@RegisterPgTableChangeListener(User, {
-  events: ['INSERT', 'UPDATE'], // Optional: specify which events to listen for
-  payloadFields: ['id', 'email'], // Optional: specify which fields to include in the payload
-})
-export class UserTableChangeListener implements PgTableChangeListener<User> {
+@RegisterPgTableChangeListener(User)
+export class UserChangeListener implements PgTableChangeListener<User> {
   async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
-    try {
-      // Handle table changes here
+    for (const insert of changes.INSERT) {
+      console.log(`New user: ${insert.data.email}`)
+    }
 
-      // Process all changes
-      changes.all.forEach((change) => {
-        console.log(`Change type: ${change.event} for user with id: ${change.data.id}`)
-
-        // Access metadata for retry information
-        if (change._metadata) {
-          console.log(`Retry count: ${change._metadata.retry_count}`)
-          console.log(`Created at: ${change._metadata.created_at}`)
-
-          // Perform different operations on retry events
-          if (change._metadata.retry_count >= 1) {
-            console.log('This is a retry - consider fetching latest data from DB')
-          }
-        }
-      })
-
-      // Process inserts
-      changes.INSERT.forEach((insert) => {
-        console.log(`New user created: ${insert.data.email}`)
-      })
-
-      // Process updates
-      changes.UPDATE.forEach((update) => {
-        console.log(`User updated: ${update.data.new.email} (was: ${update.data.old.email})`)
-        console.log(`Updated fields: ${update.data.updatedFields.join(', ')}`)
-      })
-
-      // Process deletes
-      changes.DELETE.forEach((deletion) => {
-        console.log(`User deleted: ${deletion.data.email}`)
-      })
-    } catch {
-      // If processing fails, mark all messages as failed for retry
-      if (onError) {
-        onError(changes.all.map((change) => change.id))
-      }
+    for (const update of changes.UPDATE) {
+      console.log(`Updated fields: ${update.data.updatedFields.join(', ')}`)
     }
   }
 }
 ```
 
-### 3. Subscribe to Custom Events
-
-You can also subscribe to custom PostgreSQL notification events:
-
-```typescript
-import { Injectable, OnModuleInit } from '@nestjs/common'
-import { PgPubSubService } from '@cisstech/nestjs-pg-pubsub'
-
-@Injectable()
-export class CustomEventService implements OnModuleInit {
-  constructor(private readonly pgPubSubService: PgPubSubService) {}
-
-  async onModuleInit(): Promise<void> {
-    await this.pgPubSubService.susbcribe<number>('custom-event', (payload) => {
-      console.log(`Received notification:`, payload)
-    })
-  }
-}
-```
-
-### 4. Publishing Custom Events from PostgreSQL
-
-You can publish custom events from PostgreSQL by inserting into the queue table:
-
-```sql
--- Example trigger function that publishes a custom event
-CREATE OR REPLACE FUNCTION notify_custom_event() RETURNS TRIGGER AS $$
-BEGIN
-  PERFORM pg_notify('custom-event', 'Hello world');
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER custom_event_trigger
-  AFTER INSERT ON users
-  FOR EACH ROW
-  EXECUTE PROCEDURE notify_custom_event();
-```
+That's it. The library auto-creates triggers, the queue table, and starts listening.
 
 ## How It Works
 
-### Queue-Based Architecture with Reactive Processing
+1. A PostgreSQL trigger fires on table change and inserts a row into `pg_pubsub_queue`
+2. The trigger sends a `NOTIFY` with the channel name
+3. The library receives the notification and pulls pending messages from the queue
+4. Messages are dispatched to the matching `@RegisterPgTableChangeListener` classes
+5. Processed messages are marked as such; failed ones are retried with exponential backoff
+6. A background poller runs every 60s as a safety net for missed notifications
 
-This library implements a hybrid queue-based approach to ensure reliable and efficient message processing:
+### Important Constraints
 
-1. **Message Storage**: When a database change occurs, a trigger function:
+- **Do not open transactions inside listeners.** Listeners run inside the drain loop. A long transaction blocks the loop and can cause messages to exceed their processing timeout, leading to duplicate processing. If you must write to the DB, keep it fast and non-transactional, or use `onError` to defer.
+- **Listeners must be fast.** A slow listener delays the entire batch for that table. Offload heavy work to a queue (Bull, etc.) and just enqueue from the listener.
 
-   - Generates a payload with change details
-   - Inserts the payload into a queue table
-   - Sends a notification with just the message ID
+## Configuration
 
-2. **Message Processing**:
+All options are optional except `databaseUrl`. See the [full configuration reference](https://cisstech.github.io/nestkit/docs/nestjs-pg-pubsub/advanced-usage) for details.
 
-   - The application listens for notifications and immediately pulls messages when notified
-   - Messages are processed in order using `SELECT FOR UPDATE SKIP LOCKED`
-   - A low-frequency fallback polling mechanism ensures no messages are missed
-   - Successful processing marks messages as processed
+Key tuning knobs:
 
-3. **Reliability Features**:
-   - Message persistence: All changes are stored in the database
-   - Retry mechanism: Failed messages are retried with exponential backoff
-   - TTL management: Old messages are automatically cleaned up
-   - Ordering: Messages are processed in the order they were created
-
-This approach combines the best of both worlds: reactive performance and reliable delivery.
-
-### Connection Pool
-
-All SQL operations (queue reads/writes, advisory locks, trigger DDL) go through a dedicated `pg.Pool` that is completely independent of TypeORM's connection pool. This means pg-pubsub keeps working even if your TypeORM pool is fully occupied by application queries.
-
-The pool defaults to 2 connections, which is enough for normal operation. Adjust via `pool.max` if needed.
-
-### Backpressure
-
-When PostgreSQL sends notifications faster than the application can process them, concurrent pull requests are coalesced: only one fetch cycle runs at a time, and any notifications received during processing trigger a single re-fetch once the current cycle completes. This prevents unbounded concurrent processing without dropping messages.
-
-### Trigger Change Detection
-
-On startup, the library computes an MD5 hash of each trigger's configuration (events, fields, table, schema) and compares it to the hash stored in the `pg_pubsub_trigger_meta` metadata table. Triggers are only recreated when their configuration actually changes, avoiding unnecessary DDL on every restart.
-
-### Disabling Triggers for Bulk Operations
-
-When performing bulk operations like cascade deletes, use `withTriggersDisabled` to prevent notifications:
-
-```typescript
-// With TypeORM EntityManager
-await pgPubSubService.withTriggersDisabled(async (em) => {
-  await em.getRepository(Customer).delete(customerId)
-})
-
-// With raw SQL (uses dedicated pg pool)
-await pgPubSubService.withTriggersDisabledRaw(async (query) => {
-  await query('DELETE FROM customers WHERE id = $1', [customerId])
-})
-```
+| Option                    | Default | What it controls                                                      |
+| ------------------------- | ------- | --------------------------------------------------------------------- |
+| `queue.batchSize`         | 100     | Max messages fetched per pull cycle                                   |
+| `queue.drainInterval`     | 50ms    | Pause between drain loop iterations (DB breathing room)               |
+| `queue.processingTimeout` | 5min    | After this, a `processing` message is considered orphaned and retried |
+| `pool.max`                | 5       | Connections in the dedicated pg-pubsub pool                           |
 
 ## Documentation
 
-For detailed documentation, examples, and advanced usage, please refer to the official documentation at <https://cisstech.github.io/nestkit/docs/nestjs-pg-pubsub/getting-started>
+Full documentation: <https://cisstech.github.io/nestkit/docs/nestjs-pg-pubsub/getting-started>
 
 ## License
 

--- a/libs/pg-pubsub/README.md
+++ b/libs/pg-pubsub/README.md
@@ -66,7 +66,7 @@ export class AppModule {}
 @Injectable()
 @RegisterPgTableChangeListener(User)
 export class UserChangeListener implements PgTableChangeListener<User> {
-  async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
+  async process(changes: PgTableChanges<User>, ctx: PgTableChangeContext): Promise<void> {
     for (const insert of changes.INSERT) {
       console.log(`New user: ${insert.data.email}`)
     }
@@ -91,8 +91,8 @@ That's it. The library auto-creates triggers, the queue table, and starts listen
 
 ### Important Constraints
 
-- **Do not open transactions inside listeners.** Listeners run inside the drain loop. A long transaction blocks the loop and can cause messages to exceed their processing timeout, leading to duplicate processing. If you must write to the DB, keep it fast and non-transactional, or use `onError` to defer.
 - **Listeners must be fast.** A slow listener delays the entire batch for that table. Offload heavy work to a queue (Bull, etc.) and just enqueue from the listener.
+- **Use `TransactionAdapter` for transactional writes.** If a listener needs to write to the DB inside a transaction, configure a `transactionAdapter` and mark the listener with `@RegisterPgTableChangeListener(Entity, { transactional: true })`. The library wraps the listener call in the adapter, passing an opaque transaction token via `ctx.transaction`. Without the adapter, use `ctx.onError` to signal failures.
 
 ## Configuration
 
@@ -105,6 +105,8 @@ Key tuning knobs:
 | `queue.batchSize`         | 100     | Max messages fetched per pull cycle                                   |
 | `queue.drainInterval`     | 50ms    | Pause between drain loop iterations (DB breathing room)               |
 | `queue.processingTimeout` | 5min    | After this, a `processing` message is considered orphaned and retried |
+| `queue.concurrency`       | 5       | Max listeners executing in parallel per batch                         |
+| `transactionAdapter`      | -       | ORM-agnostic adapter for wrapping listeners in transactions           |
 | `pool.max`                | 5       | Connections in the dedicated pg-pubsub pool                           |
 
 ## Documentation

--- a/libs/pg-pubsub/jest.config.ts
+++ b/libs/pg-pubsub/jest.config.ts
@@ -8,5 +8,6 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/libs/pg-pubsub',
+  testPathIgnorePatterns: ['integration', 'stress'],
   detectOpenHandles: true
 }

--- a/libs/pg-pubsub/src/lib/pg-pubsub.service.ts
+++ b/libs/pg-pubsub/src/lib/pg-pubsub.service.ts
@@ -9,6 +9,7 @@ import {
   PG_PUBSUB_FALLBACK_POLLING_INTERVAL,
   PG_PUBSUB_LOCK_DURATION,
   PgPubSubConfig,
+  ResolvedListener,
 } from './pg-pubsub'
 import {
   ListenerDiscoveryService,
@@ -44,6 +45,8 @@ export class PgPubSubService implements OnModuleInit, OnModuleDestroy {
 
   async onModuleInit(): Promise<void> {
     this.discovery = await this.listenerDiscoveryService.discoverListeners()
+
+    this.validateTransactionalListeners()
 
     await this.pgLockService.tryLock({
       key: 'pg_pubsub',
@@ -198,6 +201,19 @@ export class PgPubSubService implements OnModuleInit, OnModuleDestroy {
 
   private async setupListenersAndTriggers(): Promise<void> {
     await this.triggerService.setupTriggers(this.discovery)
+  }
+
+  private validateTransactionalListeners(): void {
+    const hasTransactional = Object.values(this.discovery.listenersMap)
+      .flat()
+      .some((l: ResolvedListener) => l.transactional)
+
+    if (hasTransactional && !this.config.transactionAdapter) {
+      throw new Error(
+        'pg-pubsub: transactional listeners detected but no transactionAdapter provided in config. ' +
+          'Either remove transactional: true from your listeners or provide a transactionAdapter in PgPubSubModule.forRoot().'
+      )
+    }
   }
 
   private async listenForChanges(): Promise<void> {

--- a/libs/pg-pubsub/src/lib/pg-pubsub.service.ts
+++ b/libs/pg-pubsub/src/lib/pg-pubsub.service.ts
@@ -3,7 +3,13 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import createPostgresSubscriber, { Subscriber } from 'pg-listen'
 import { Subscription, interval } from 'rxjs'
 import { DataSource, EntityManager } from 'typeorm'
-import { ListenerDiscovery, PG_PUBSUB_CONFIG, PgPubSubConfig } from './pg-pubsub'
+import {
+  ListenerDiscovery,
+  PG_PUBSUB_CONFIG,
+  PG_PUBSUB_FALLBACK_POLLING_INTERVAL,
+  PG_PUBSUB_LOCK_DURATION,
+  PgPubSubConfig,
+} from './pg-pubsub'
 import {
   ListenerDiscoveryService,
   MessageProcessorService,
@@ -41,21 +47,22 @@ export class PgPubSubService implements OnModuleInit, OnModuleDestroy {
 
     await this.pgLockService.tryLock({
       key: 'pg_pubsub',
-      duration: 5_000,
+      duration: this.config.lockDuration ?? PG_PUBSUB_LOCK_DURATION,
       onAccept: async () => {
-        await this.queueService.setup()
+        await this.queueService.ensureQueueTable()
         await this.setupListenersAndTriggers()
       },
       onReject: () => this.logger.warn('Another instance is already updating PubSub triggers'),
     })
 
+    await this.queueService.startWorker()
     await this.resume()
   }
 
   async onModuleDestroy(): Promise<void> {
     this.pollingSubscription?.unsubscribe()
 
-    await this.queueService.teardown()
+    await this.queueService.stopWorker()
     await this.postgresSubscriber?.close()
   }
 
@@ -207,7 +214,7 @@ export class PgPubSubService implements OnModuleInit, OnModuleDestroy {
     })
 
     // Fallback polling to catch messages missed due to notification failures
-    const fallbackInterval = 60_000
+    const fallbackInterval = this.config.fallbackPollingInterval ?? PG_PUBSUB_FALLBACK_POLLING_INTERVAL
     this.pollingSubscription = interval(fallbackInterval).subscribe(() => {
       this.messageProcessorService.pullAndProcessMessages(this.config.triggerPrefix!, this.discovery).catch((error) => {
         this.logger.error('Error during fallback message polling:', error)

--- a/libs/pg-pubsub/src/lib/pg-pubsub.stress.spec.ts
+++ b/libs/pg-pubsub/src/lib/pg-pubsub.stress.spec.ts
@@ -1,0 +1,314 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm'
+import { Column, DataSource, Entity, PrimaryGeneratedColumn, Repository } from 'typeorm'
+import {
+  PgPubSubModule,
+  PgPubSubService,
+  PgTableChangeListener,
+  PgTableChanges,
+  RegisterPgTableChangeListener,
+} from '..'
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { createTestDatabase } from '@cisstech/testing'
+
+const MESSAGE_COUNT = parseInt(process.env['STRESS_MESSAGE_COUNT'] || '1000', 10)
+const BATCH_SIZE = parseInt(process.env['STRESS_BATCH_SIZE'] || '50', 10)
+const TIMEOUT_MS = parseInt(process.env['STRESS_TIMEOUT_MS'] || '60000', 10)
+
+const QUEUE_TABLE = 'stress_pg_pubsub_queue'
+
+@Entity('stress_users')
+class StressUser {
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @Column()
+  name!: string
+
+  @Column()
+  email!: string
+}
+
+@Entity('stress_orders')
+class StressOrder {
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @Column()
+  product!: string
+
+  @Column({ type: 'int' })
+  quantity!: number
+}
+
+@RegisterPgTableChangeListener(StressUser)
+class StressUserListener implements PgTableChangeListener<StressUser> {
+  receivedIds: number[] = []
+  processingDelay = 0
+
+  async process(changes: PgTableChanges<StressUser>): Promise<void> {
+    for (const change of changes.all) {
+      this.receivedIds.push(change.id)
+    }
+    if (this.processingDelay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.processingDelay))
+    }
+  }
+}
+
+@RegisterPgTableChangeListener(StressOrder)
+class StressOrderListener implements PgTableChangeListener<StressOrder> {
+  receivedIds: number[] = []
+  processingDelay = 0
+
+  async process(changes: PgTableChanges<StressOrder>): Promise<void> {
+    for (const change of changes.all) {
+      this.receivedIds.push(change.id)
+    }
+    if (this.processingDelay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.processingDelay))
+    }
+  }
+}
+
+async function insertUsers(repo: Repository<StressUser>, total: number, batchSize: number, offset = 0): Promise<void> {
+  for (let i = 0; i < total; i += batchSize) {
+    const size = Math.min(batchSize, total - i)
+    await Promise.all(
+      Array.from({ length: size }, (_, j) =>
+        repo.save({ name: `User ${offset + i + j}`, email: `user${offset + i + j}@stress.test` })
+      )
+    )
+  }
+}
+
+async function insertOrders(repo: Repository<StressOrder>, total: number, batchSize: number): Promise<void> {
+  for (let i = 0; i < total; i += batchSize) {
+    const size = Math.min(batchSize, total - i)
+    await Promise.all(
+      Array.from({ length: size }, (_, j) => repo.save({ product: `Product ${i + j}`, quantity: i + j + 1 }))
+    )
+  }
+}
+
+async function waitFor(check: () => boolean, timeoutMs: number, intervalMs = 200): Promise<void> {
+  const start = Date.now()
+  while (!check() && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+}
+
+interface QueueStats {
+  pending: number
+  processing: number
+  processed: number
+  failed: number
+}
+
+async function getQueueStats(dataSource: DataSource): Promise<QueueStats> {
+  const rows = await dataSource.query(`SELECT status, count(*)::int as cnt FROM "${QUEUE_TABLE}" GROUP BY status`)
+  const stats: QueueStats = { pending: 0, processing: 0, processed: 0, failed: 0 }
+  for (const row of rows) {
+    stats[row.status as keyof QueueStats] = row.cnt
+  }
+  return stats
+}
+
+describe('PgPubSub Stress Tests', () => {
+  let app: INestApplication
+  let dataSource: DataSource
+  let userRepo: Repository<StressUser>
+  let orderRepo: Repository<StressOrder>
+  let userListener: StressUserListener
+  let orderListener: StressOrderListener
+  let pgPubSub: PgPubSubService
+
+  beforeAll(async () => {
+    const testDbUrl = await createTestDatabase()
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          url: testDbUrl,
+          entities: [StressUser, StressOrder],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([StressUser, StressOrder]),
+        PgPubSubModule.forRoot({
+          databaseUrl: testDbUrl,
+          triggerPrefix: 'stress_pubsub',
+          queue: {
+            table: QUEUE_TABLE,
+            maxRetries: 3,
+            batchSize: 20,
+            drainInterval: 10,
+            processingTimeout: 2000,
+          },
+        }),
+      ],
+      providers: [StressUserListener, StressOrderListener],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+    await app.init()
+
+    dataSource = app.get(DataSource)
+    userRepo = app.get(getRepositoryToken(StressUser))
+    orderRepo = app.get(getRepositoryToken(StressOrder))
+    userListener = app.get(StressUserListener)
+    orderListener = app.get(StressOrderListener)
+    pgPubSub = app.get(PgPubSubService)
+
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+  }, 30000)
+
+  afterAll(async () => {
+    await app?.close()
+  }, 15000)
+
+  beforeEach(async () => {
+    userListener.receivedIds = []
+    userListener.processingDelay = 0
+    orderListener.receivedIds = []
+    orderListener.processingDelay = 0
+
+    await pgPubSub.withTriggersDisabled(async (em) => {
+      await em.query('DELETE FROM stress_users')
+      await em.query('DELETE FROM stress_orders')
+    })
+    await dataSource.query(`DELETE FROM "${QUEUE_TABLE}"`)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  })
+
+  it(
+    'zero message loss under slow consumer backpressure',
+    async () => {
+      userListener.processingDelay = 50
+
+      await insertUsers(userRepo, MESSAGE_COUNT, BATCH_SIZE)
+
+      await waitFor(() => userListener.receivedIds.length >= MESSAGE_COUNT, TIMEOUT_MS)
+
+      const stats = await getQueueStats(dataSource)
+
+      console.log(`  [backpressure] ${userListener.receivedIds.length}/${MESSAGE_COUNT} received`)
+      console.log(
+        `  [backpressure] queue: processed=${stats.processed} pending=${stats.pending} processing=${stats.processing} failed=${stats.failed}`
+      )
+
+      expect(userListener.receivedIds.length).toBe(MESSAGE_COUNT)
+      expect(stats.pending).toBe(0)
+      expect(stats.processing).toBe(0)
+      expect(stats.failed).toBe(0)
+    },
+    TIMEOUT_MS + 30000
+  )
+
+  it(
+    'pause/resume preserves all in-flight and queued messages',
+    async () => {
+      const half = Math.floor(MESSAGE_COUNT / 2)
+
+      await insertUsers(userRepo, half, BATCH_SIZE)
+
+      await waitFor(() => userListener.receivedIds.length > 0, 5000, 50)
+      const beforePause = userListener.receivedIds.length
+
+      await pgPubSub.pause()
+
+      await insertUsers(userRepo, half, BATCH_SIZE, half)
+
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      const duringPause = userListener.receivedIds.length
+
+      await pgPubSub.resume()
+
+      await waitFor(() => userListener.receivedIds.length >= MESSAGE_COUNT, TIMEOUT_MS)
+
+      const stats = await getQueueStats(dataSource)
+
+      console.log(
+        `  [pause/resume] before=${beforePause} during=${duringPause} final=${userListener.receivedIds.length}/${MESSAGE_COUNT}`
+      )
+      console.log(
+        `  [pause/resume] queue: processed=${stats.processed} pending=${stats.pending} failed=${stats.failed}`
+      )
+
+      expect(userListener.receivedIds.length).toBe(MESSAGE_COUNT)
+      expect(stats.pending).toBe(0)
+      expect(stats.failed).toBe(0)
+    },
+    TIMEOUT_MS + 30000
+  )
+
+  it(
+    'concurrent writers produce no duplicates and no loss',
+    async () => {
+      const writers = 5
+      const perWriter = Math.ceil(MESSAGE_COUNT / writers)
+
+      await Promise.all(
+        Array.from({ length: writers }, (_, w) => insertUsers(userRepo, perWriter, BATCH_SIZE, w * perWriter))
+      )
+
+      const totalExpected = perWriter * writers
+
+      await waitFor(() => userListener.receivedIds.length >= totalExpected, TIMEOUT_MS)
+
+      const stats = await getQueueStats(dataSource)
+      const uniqueIds = new Set(userListener.receivedIds)
+
+      console.log(
+        `  [concurrent] ${userListener.receivedIds.length}/${totalExpected} received, ${uniqueIds.size} unique`
+      )
+      console.log(
+        `  [concurrent] queue: processed=${stats.processed} pending=${stats.pending} processing=${stats.processing} failed=${stats.failed}`
+      )
+
+      expect(uniqueIds.size).toBe(userListener.receivedIds.length)
+      expect(userListener.receivedIds.length).toBe(totalExpected)
+      expect(stats.pending).toBe(0)
+      expect(stats.processing).toBe(0)
+      expect(stats.failed).toBe(0)
+    },
+    TIMEOUT_MS + 30000
+  )
+
+  it(
+    'concurrent multi-table processing with no cross-contamination',
+    async () => {
+      userListener.processingDelay = 100
+      orderListener.processingDelay = 0
+
+      const half = Math.floor(MESSAGE_COUNT / 2)
+
+      await Promise.all([insertUsers(userRepo, half, BATCH_SIZE), insertOrders(orderRepo, half, BATCH_SIZE)])
+
+      await waitFor(
+        () => userListener.receivedIds.length >= half && orderListener.receivedIds.length >= half,
+        TIMEOUT_MS
+      )
+
+      const stats = await getQueueStats(dataSource)
+      const userIdSet = new Set(userListener.receivedIds)
+      const orderIdSet = new Set(orderListener.receivedIds)
+      const overlap = [...userIdSet].filter((id) => orderIdSet.has(id))
+
+      console.log(
+        `  [multi-table] users=${userListener.receivedIds.length}/${half} orders=${orderListener.receivedIds.length}/${half}`
+      )
+      console.log(`  [multi-table] queue: processed=${stats.processed} pending=${stats.pending} failed=${stats.failed}`)
+      console.log(`  [multi-table] cross-contamination: ${overlap.length} overlapping IDs`)
+
+      expect(userListener.receivedIds.length).toBe(half)
+      expect(orderListener.receivedIds.length).toBe(half)
+      expect(overlap).toHaveLength(0)
+      expect(stats.pending).toBe(0)
+      expect(stats.failed).toBe(0)
+    },
+    TIMEOUT_MS + 30000
+  )
+})

--- a/libs/pg-pubsub/src/lib/pg-pubsub.ts
+++ b/libs/pg-pubsub/src/lib/pg-pubsub.ts
@@ -44,6 +44,33 @@ export const PG_PUBSUB_QUEUE_CLEANUP_INTERVAL = 60 * 60 * 1000
 export const PG_PUBSUB_QUEUE_BATCH_SIZE = 100
 
 /**
+ * Default processing timeout in milliseconds.
+ * Messages stuck in 'processing' longer than this are considered orphaned.
+ */
+export const PG_PUBSUB_QUEUE_PROCESSING_TIMEOUT = 5 * 60 * 1000
+
+/**
+ * Default fallback polling interval in milliseconds.
+ */
+export const PG_PUBSUB_FALLBACK_POLLING_INTERVAL = 60_000
+
+/**
+ * Default advisory lock duration in milliseconds.
+ */
+export const PG_PUBSUB_LOCK_DURATION = 5_000
+
+/**
+ * Default delay in milliseconds between drain loop iterations.
+ * Gives the database breathing room under high message volume.
+ */
+export const PG_PUBSUB_DRAIN_INTERVAL = 50
+
+/**
+ * Default maximum number of connections in the dedicated pool.
+ */
+export const PG_PUBSUB_POOL_MAX = 5
+
+/**
  * Type for a PostgreSQL table INSERT payload.
  */
 export type PgTableInsertPayload<TRow = unknown> = {
@@ -266,6 +293,19 @@ export type PgPubSubConfig = {
   queue?: QueueConfig
 
   /**
+   * Fallback polling interval in milliseconds.
+   * Messages are polled at this interval as a safety net in case LISTEN/NOTIFY misses events.
+   * @default PG_PUBSUB_FALLBACK_POLLING_INTERVAL
+   */
+  fallbackPollingInterval?: number
+
+  /**
+   * Duration of the advisory lock in milliseconds for DDL/trigger setup.
+   * @default PG_PUBSUB_LOCK_DURATION
+   */
+  lockDuration?: number
+
+  /**
    * Dedicated PG pool configuration.
    * This pool is independent of TypeORM's connection pool, ensuring that
    * pg-pubsub operations are never blocked by TypeORM pool exhaustion.
@@ -340,9 +380,23 @@ export interface QueueConfig {
 
   /**
    * Maximum number of messages to fetch per pull cycle.
-   * @default 100
+   * @default PG_PUBSUB_QUEUE_BATCH_SIZE
    */
   batchSize?: number
+
+  /**
+   * Timeout in milliseconds after which a 'processing' message is considered orphaned.
+   * Must be long enough for your slowest listener to complete.
+   * @default PG_PUBSUB_QUEUE_PROCESSING_TIMEOUT
+   */
+  processingTimeout?: number
+
+  /**
+   * Delay in milliseconds between drain loop iterations.
+   * Prevents tight-looping under high message volume.
+   * @default PG_PUBSUB_DRAIN_INTERVAL
+   */
+  drainInterval?: number
 }
 
 /**
@@ -351,7 +405,7 @@ export interface QueueConfig {
 export interface PoolConfig {
   /**
    * Maximum number of connections in the dedicated pool.
-   * @default 2
+   * @default PG_PUBSUB_POOL_MAX
    */
   max?: number
 }

--- a/libs/pg-pubsub/src/lib/pg-pubsub.ts
+++ b/libs/pg-pubsub/src/lib/pg-pubsub.ts
@@ -71,6 +71,11 @@ export const PG_PUBSUB_DRAIN_INTERVAL = 50
 export const PG_PUBSUB_POOL_MAX = 5
 
 /**
+ * Default maximum number of concurrent listener executions.
+ */
+export const PG_PUBSUB_QUEUE_CONCURRENCY = 5
+
+/**
  * Type for a PostgreSQL table INSERT payload.
  */
 export type PgTableInsertPayload<TRow = unknown> = {
@@ -193,15 +198,42 @@ export type PgTableChanges<TRow = unknown> = {
 export type PgTableChangeErrorHandler = (ids: number[]) => void
 
 /**
+ * ORM-agnostic adapter for running listener logic inside a transaction.
+ * TToken is opaque to the library (e.g. EntityManager for TypeORM, PrismaClient for Prisma).
+ */
+export interface TransactionAdapter<TToken = unknown> {
+  /** Open a transaction, execute the callback, commit on success or rollback on error. */
+  run<T>(callback: (token: TToken) => Promise<T>): Promise<T>
+}
+
+/**
+ * Context passed to a listener's `process` method.
+ */
+export interface PgTableChangeContext<TToken = unknown> {
+  /** Callback to signal specific message IDs as failed (non-transactional mode). */
+  onError: PgTableChangeErrorHandler
+  /** Opaque transaction token. Present only when `transactional: true` and a transactionAdapter is configured. */
+  transaction?: TToken
+}
+
+/**
  * Type for a handler that listens to changes on a PostgreSQL table.
  */
-export interface PgTableChangeListener<TRow> {
+export interface PgTableChangeListener<TRow, TToken = unknown> {
   /**
    * Process the batch of changes received for a PostgreSQL table.
    * @param changes The batch of changes for the table.
-   * @param onError Callback to handle errors when processing a change. (used to mark the message as failed and retry later)
+   * @param ctx Context with error handling and optional transaction token.
    */
-  process(changes: PgTableChanges<TRow>, onError?: PgTableChangeErrorHandler): Promise<void>
+  process(changes: PgTableChanges<TRow>, ctx: PgTableChangeContext<TToken>): Promise<void>
+}
+
+/**
+ * A discovered listener with its resolved metadata.
+ */
+export interface ResolvedListener<TRow = unknown> {
+  instance: PgTableChangeListener<TRow>
+  transactional: boolean
 }
 
 /**
@@ -241,6 +273,13 @@ export type RegisterPgTableChangeListenerMetadata<T = any> = {
    * - If multiple listeners are registered for the same table, the values of this field will be merged.
    */
   payloadFields?: (keyof T)[]
+
+  /**
+   * Whether the listener should be invoked inside a transaction managed by the configured transactionAdapter.
+   * Requires a `transactionAdapter` in the module config. Validated at boot time.
+   * @default false
+   */
+  transactional?: boolean
 }
 
 /**
@@ -311,6 +350,12 @@ export type PgPubSubConfig = {
    * pg-pubsub operations are never blocked by TypeORM pool exhaustion.
    */
   pool?: PoolConfig
+
+  /**
+   * ORM-agnostic transaction adapter for listeners marked with `transactional: true`.
+   * The library calls `adapter.run()` to wrap listener execution in a transaction.
+   */
+  transactionAdapter?: TransactionAdapter
 
   /**
    * Custom lock service to use
@@ -397,6 +442,13 @@ export interface QueueConfig {
    * @default PG_PUBSUB_DRAIN_INTERVAL
    */
   drainInterval?: number
+
+  /**
+   * Maximum number of listener executions running in parallel.
+   * Limits the number of concurrent transactions / async operations.
+   * @default PG_PUBSUB_QUEUE_CONCURRENCY
+   */
+  concurrency?: number
 }
 
 /**
@@ -465,8 +517,8 @@ export interface ListenerDiscovery {
   /** Table listeners. */
   listeners: TableListener[]
 
-  /** Map of listeners by table name. */
-  listenersMap: Record<string, PgTableChangeListener<unknown>[]>
+  /** Map of resolved listeners by table name. */
+  listenersMap: Record<string, ResolvedListener<unknown>[]>
 
   /** List of entity metadata. */
   entityMetadataList: EntityMetadata[]

--- a/libs/pg-pubsub/src/lib/semaphore.ts
+++ b/libs/pg-pubsub/src/lib/semaphore.ts
@@ -1,0 +1,23 @@
+export class Semaphore {
+  private current = 0
+  private readonly waiting: (() => void)[] = []
+
+  constructor(private readonly max: number) {}
+
+  async acquire(): Promise<void> {
+    if (this.current < this.max) {
+      this.current++
+      return
+    }
+    return new Promise<void>((resolve) => this.waiting.push(resolve))
+  }
+
+  release(): void {
+    this.current--
+    const next = this.waiting.shift()
+    if (next) {
+      this.current++
+      next()
+    }
+  }
+}

--- a/libs/pg-pubsub/src/lib/services/listener-discovery.service.ts
+++ b/libs/pg-pubsub/src/lib/services/listener-discovery.service.ts
@@ -10,6 +10,7 @@ import {
   PgTableChangeListener,
   RegisterPgTableChangeListenerMeta,
   RegisterPgTableChangeListenerMetadata,
+  ResolvedListener,
   TableListener,
 } from '../pg-pubsub'
 
@@ -66,7 +67,7 @@ export class ListenerDiscoveryService {
 
     const tableNames = listeners.map((t) => t.table)
 
-    // Build listener map (table name -> array of listener instances)
+    // Build listener map (table name -> array of resolved listener instances)
     const listenersMap = providers.reduce(
       (acc, provider) => {
         const tableMeta = this.dataSource.getMetadata(provider.meta.target)
@@ -85,11 +86,14 @@ export class ListenerDiscoveryService {
 
         acc[tableName] = [
           ...(acc[tableName] || []),
-          provider.discoveredClass.instance as PgTableChangeListener<unknown>,
+          {
+            instance: provider.discoveredClass.instance as PgTableChangeListener<unknown>,
+            transactional: provider.meta.transactional ?? false,
+          },
         ]
         return acc
       },
-      {} as Record<string, PgTableChangeListener<unknown>[]>
+      {} as Record<string, ResolvedListener<unknown>[]>
     )
 
     return {

--- a/libs/pg-pubsub/src/lib/services/message-processor.service.spec.ts
+++ b/libs/pg-pubsub/src/lib/services/message-processor.service.spec.ts
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Test } from '@nestjs/testing'
-import { ListenerDiscovery, PG_PUBSUB_CONFIG, PgTableChangeListener, PgTableInsertPayload } from '../pg-pubsub'
+import {
+  ListenerDiscovery,
+  PG_PUBSUB_CONFIG,
+  PgTableChangeContext,
+  PgTableChangeListener,
+  PgTableInsertPayload,
+  ResolvedListener,
+} from '../pg-pubsub'
 import { MessageProcessorService } from './message-processor.service'
 import { QueueService } from './queue.service'
 
@@ -69,7 +76,7 @@ describe('MessageProcessorService', () => {
           users: new Map([['name', 'name']]),
         },
         listenersMap: {
-          users: [] as unknown as PgTableChangeListener<unknown>[],
+          users: [] as ResolvedListener<unknown>[],
         },
         tableNames: ['users'],
       })
@@ -150,9 +157,9 @@ describe('MessageProcessorService', () => {
         process: jest.fn().mockResolvedValue(undefined),
       }
 
-      const listenersMap = {
-        users: [usersListener],
-        roles: [rolesListener],
+      const listenersMap: Record<string, ResolvedListener<unknown>[]> = {
+        users: [{ instance: usersListener, transactional: false }],
+        roles: [{ instance: rolesListener, transactional: false }],
       }
 
       await messageProcessorService['processChanges'](changes, listenersMap)
@@ -163,7 +170,7 @@ describe('MessageProcessorService', () => {
           all: expect.arrayContaining([changes[0]]),
           INSERT: expect.arrayContaining([changes[0]]),
         }),
-        expect.anything()
+        expect.objectContaining({ onError: expect.any(Function) })
       )
 
       expect(rolesListener.process).toHaveBeenCalledWith(
@@ -171,7 +178,7 @@ describe('MessageProcessorService', () => {
           all: expect.arrayContaining([changes[1]]),
           INSERT: expect.arrayContaining([changes[1]]),
         }),
-        expect.anything()
+        expect.objectContaining({ onError: expect.any(Function) })
       )
     })
 
@@ -191,8 +198,8 @@ describe('MessageProcessorService', () => {
         process: jest.fn().mockRejectedValue(new Error('Processing failed')),
       }
 
-      const listenersMap = {
-        users: [usersListener],
+      const listenersMap: Record<string, ResolvedListener<unknown>[]> = {
+        users: [{ instance: usersListener, transactional: false }],
       }
 
       await messageProcessorService['processChanges'](changes, listenersMap)
@@ -225,8 +232,8 @@ describe('MessageProcessorService', () => {
         process: jest.fn().mockResolvedValue(undefined),
       }
 
-      const listenersMap = {
-        users: [usersListener],
+      const listenersMap: Record<string, ResolvedListener<unknown>[]> = {
+        users: [{ instance: usersListener, transactional: false }],
       }
 
       await messageProcessorService['processChanges'](changes, listenersMap)
@@ -238,8 +245,99 @@ describe('MessageProcessorService', () => {
           all: expect.arrayContaining([changes[0], changes[1]]),
           INSERT: expect.arrayContaining([changes[0], changes[1]]),
         }),
-        expect.anything()
+        expect.objectContaining({ onError: expect.any(Function) })
       )
+    })
+
+    it('should wrap transactional listeners with the transaction adapter', async () => {
+      const changes = [
+        {
+          id: 1,
+          event: 'INSERT' as const,
+          table: 'users',
+          data: { name: 'Test User' },
+        },
+      ]
+
+      const fakeToken = { fake: 'entityManager' }
+      const usersListener: PgTableChangeListener<unknown> = {
+        process: jest.fn().mockResolvedValue(undefined),
+      }
+
+      const listenersMap: Record<string, ResolvedListener<unknown>[]> = {
+        users: [{ instance: usersListener, transactional: true }],
+      }
+
+      // Inject a transaction adapter
+      ;(messageProcessorService as any).transactionAdapter = {
+        run: jest.fn().mockImplementation(async (cb: any) => cb(fakeToken)),
+      }
+
+      await messageProcessorService['processChanges'](changes, listenersMap)
+
+      expect(usersListener.process).toHaveBeenCalledWith(
+        expect.objectContaining({ all: expect.arrayContaining([changes[0]]) }),
+        expect.objectContaining({ transaction: fakeToken })
+      )
+    })
+
+    it('should mark all messages as failed when transactional listener throws', async () => {
+      const changes = [
+        { id: 1, event: 'INSERT' as const, table: 'users', data: {} },
+        { id: 2, event: 'INSERT' as const, table: 'users', data: {} },
+      ]
+
+      const usersListener: PgTableChangeListener<unknown> = {
+        process: jest.fn().mockRejectedValue(new Error('tx failed')),
+      }
+
+      const listenersMap: Record<string, ResolvedListener<unknown>[]> = {
+        users: [{ instance: usersListener, transactional: true }],
+      }
+
+      ;(messageProcessorService as any).transactionAdapter = {
+        run: jest.fn().mockImplementation(async (cb: any) => cb({})),
+      }
+
+      await messageProcessorService['processChanges'](changes, listenersMap)
+
+      expect(queueService.markAsFailed).toHaveBeenCalledWith([1, 2])
+      expect(queueService.markAsProcessed).toHaveBeenCalledWith([])
+    })
+
+    it('should respect concurrency limit', async () => {
+      let concurrent = 0
+      let maxConcurrent = 0
+
+      const slowListener: PgTableChangeListener<unknown> = {
+        process: jest.fn().mockImplementation(async () => {
+          concurrent++
+          maxConcurrent = Math.max(maxConcurrent, concurrent)
+          await new Promise((r) => setTimeout(r, 10))
+          concurrent--
+        }),
+      }
+
+      // 3 tables, each with 1 listener, concurrency = 2
+      const changes = [
+        { id: 1, event: 'INSERT' as const, table: 'a', data: {} },
+        { id: 2, event: 'INSERT' as const, table: 'b', data: {} },
+        { id: 3, event: 'INSERT' as const, table: 'c', data: {} },
+      ]
+
+      const listenersMap: Record<string, ResolvedListener<unknown>[]> = {
+        a: [{ instance: slowListener, transactional: false }],
+        b: [{ instance: slowListener, transactional: false }],
+        c: [{ instance: slowListener, transactional: false }],
+      }
+
+      // Replace semaphore with concurrency 2
+      ;(messageProcessorService as any).semaphore = new (require('../semaphore').Semaphore)(2)
+
+      await messageProcessorService['processChanges'](changes, listenersMap)
+
+      expect(maxConcurrent).toBeLessThanOrEqual(2)
+      expect(slowListener.process).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/libs/pg-pubsub/src/lib/services/message-processor.service.spec.ts
+++ b/libs/pg-pubsub/src/lib/services/message-processor.service.spec.ts
@@ -3,11 +3,11 @@ import { Test } from '@nestjs/testing'
 import {
   ListenerDiscovery,
   PG_PUBSUB_CONFIG,
-  PgTableChangeContext,
   PgTableChangeListener,
   PgTableInsertPayload,
   ResolvedListener,
 } from '../pg-pubsub'
+import { Semaphore } from '../semaphore'
 import { MessageProcessorService } from './message-processor.service'
 import { QueueService } from './queue.service'
 
@@ -332,7 +332,7 @@ describe('MessageProcessorService', () => {
       }
 
       // Replace semaphore with concurrency 2
-      ;(messageProcessorService as any).semaphore = new (require('../semaphore').Semaphore)(2)
+      ;(messageProcessorService as any).semaphore = new Semaphore(2)
 
       await messageProcessorService['processChanges'](changes, listenersMap)
 

--- a/libs/pg-pubsub/src/lib/services/message-processor.service.spec.ts
+++ b/libs/pg-pubsub/src/lib/services/message-processor.service.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Test } from '@nestjs/testing'
-import { ListenerDiscovery, PgTableChangeListener, PgTableInsertPayload } from '../pg-pubsub'
+import { ListenerDiscovery, PG_PUBSUB_CONFIG, PgTableChangeListener, PgTableInsertPayload } from '../pg-pubsub'
 import { MessageProcessorService } from './message-processor.service'
 import { QueueService } from './queue.service'
 
@@ -37,6 +37,10 @@ describe('MessageProcessorService', () => {
           provide: QueueService,
           useValue: queueService,
         },
+        {
+          provide: PG_PUBSUB_CONFIG,
+          useValue: { queue: { drainInterval: 0 } },
+        },
       ],
     }).compile()
 
@@ -70,13 +74,14 @@ describe('MessageProcessorService', () => {
         tableNames: ['users'],
       })
 
-      // Mock queue service to return messages
-      queueService.fetchPendingMessages.mockResolvedValue(mockMessages)
+      // Mock queue service to return messages, then empty on drain
+      queueService.fetchPendingMessages.mockResolvedValueOnce(mockMessages).mockResolvedValueOnce([])
 
       await messageProcessorService.pullAndProcessMessages('test_channel', mockDiscovery)
 
       // Verify messages were processed
       expect(queueService.fetchPendingMessages).toHaveBeenCalledWith('test_channel')
+      expect(queueService.fetchPendingMessages).toHaveBeenCalledTimes(2)
       expect(queueService.markAsProcessed).toHaveBeenCalledWith([1])
     })
 
@@ -97,7 +102,7 @@ describe('MessageProcessorService', () => {
       const mockDiscovery = createListenerDiscovery()
 
       // Mock queue service to return messages
-      queueService.fetchPendingMessages.mockResolvedValue(mockMessages)
+      queueService.fetchPendingMessages.mockResolvedValueOnce(mockMessages).mockResolvedValueOnce([])
 
       await messageProcessorService.pullAndProcessMessages('test_channel', mockDiscovery)
 
@@ -190,11 +195,12 @@ describe('MessageProcessorService', () => {
         users: [usersListener],
       }
 
-      // This should not throw
       await messageProcessorService['processChanges'](changes, listenersMap)
 
-      // Verify call didn't crash the service
+      // Verify listener was called and message IDs were marked as failed
       expect(usersListener.process).toHaveBeenCalled()
+      expect(queueService.markAsFailed).toHaveBeenCalledWith([1])
+      expect(queueService.markAsProcessed).toHaveBeenCalledWith([])
     })
 
     it('should group changes by table', async () => {

--- a/libs/pg-pubsub/src/lib/services/message-processor.service.ts
+++ b/libs/pg-pubsub/src/lib/services/message-processor.service.ts
@@ -3,14 +3,18 @@ import {
   ListenerDiscovery,
   PG_PUBSUB_CONFIG,
   PG_PUBSUB_DRAIN_INTERVAL,
+  PG_PUBSUB_QUEUE_CONCURRENCY,
   PgPubSubConfig,
-  PgTableChangeListener,
+  PgTableChangeContext,
   PgTableChangePayload,
   PgTableChanges,
   PgTableDeletePayload,
   PgTableInsertPayload,
   PgTableUpdatePayload,
+  ResolvedListener,
+  TransactionAdapter,
 } from '../pg-pubsub'
+import { Semaphore } from '../semaphore'
 import { createEntity } from '../pg-pubsub.utils'
 import { QueueService } from './queue.service'
 
@@ -27,11 +31,19 @@ export class MessageProcessorService {
   /** Delay between drain loop iterations in milliseconds. */
   private readonly drainInterval: number
 
+  /** Limits parallel listener executions. */
+  private readonly semaphore: Semaphore
+
+  /** Optional transaction adapter provided by the application. */
+  private readonly transactionAdapter?: TransactionAdapter
+
   constructor(
     private readonly queueService: QueueService,
     @Inject(PG_PUBSUB_CONFIG) config: PgPubSubConfig
   ) {
     this.drainInterval = config.queue?.drainInterval ?? PG_PUBSUB_DRAIN_INTERVAL
+    this.semaphore = new Semaphore(config.queue?.concurrency ?? PG_PUBSUB_QUEUE_CONCURRENCY)
+    this.transactionAdapter = config.transactionAdapter
   }
 
   /**
@@ -158,7 +170,7 @@ export class MessageProcessorService {
    */
   private async processChanges<T>(
     payloads: PgTableChangePayload<T>[],
-    listenersMap: Record<string, PgTableChangeListener<unknown>[]>
+    listenersMap: Record<string, ResolvedListener<unknown>[]>
   ): Promise<void> {
     payloads = payloads.sort((a, b) => a.id - b.id)
     const groupByTables = payloads.reduce(
@@ -182,7 +194,7 @@ export class MessageProcessorService {
     this.logger.log(`Processing changes: ${tableBreakdown}`)
 
     for (const [table, changes] of Object.entries(groupByTables)) {
-      const listeners = listenersMap[table] ?? []
+      const resolvedListeners = listenersMap[table] ?? []
 
       const inserts = changes.filter((c) => c.event === 'INSERT') as PgTableInsertPayload<T>[]
       const updates = changes.filter((c) => c.event === 'UPDATE') as PgTableUpdatePayload<T>[]
@@ -190,31 +202,65 @@ export class MessageProcessorService {
 
       const changeIds = changes.map((c) => c.id)
 
-      listeners.forEach((listener) => {
-        this.logger.debug(`Routing ${changes.length} changes to ${listener.constructor.name} for table ${table}`)
-        promises.push(
-          listener
-            .process(
-              {
-                all: changes,
-                INSERT: inserts || [],
-                UPDATE: updates || [],
-                DELETE: deletes || [],
-              } as PgTableChanges<unknown>,
-              (ids) => failedIds.push(...ids)
-            )
-            .catch((error) => {
-              this.logger.error(`Error processing changes for table ${table} in ${listener.constructor.name}:`, error)
-              failedIds.push(...changeIds)
-            })
+      const batch: PgTableChanges<unknown> = {
+        all: changes,
+        INSERT: inserts || [],
+        UPDATE: updates || [],
+        DELETE: deletes || [],
+      }
+
+      for (const resolved of resolvedListeners) {
+        this.logger.debug(
+          `Routing ${changes.length} changes to ${resolved.instance.constructor.name} for table ${table}`
         )
-      })
+
+        const task = this.executeListener(resolved, batch, changeIds, failedIds, table)
+        promises.push(task)
+      }
     }
 
     await Promise.all(promises)
     await this.queueService.markAsProcessed(payloads.filter((v) => !failedIds.includes(v.id)).map((v) => v.id))
     if (failedIds.length > 0) {
       await this.queueService.markAsFailed(failedIds)
+    }
+  }
+
+  private async executeListener(
+    resolved: ResolvedListener<unknown>,
+    batch: PgTableChanges<unknown>,
+    changeIds: number[],
+    failedIds: number[],
+    table: string
+  ): Promise<void> {
+    await this.semaphore.acquire()
+    try {
+      if (resolved.transactional && this.transactionAdapter) {
+        await this.transactionAdapter.run(async (token) => {
+          const ctx: PgTableChangeContext = {
+            onError: () => {
+              /* noop in transactional mode: throw to rollback instead */
+            },
+            transaction: token,
+          }
+          await resolved.instance.process(batch, ctx)
+        })
+      } else {
+        const ctx: PgTableChangeContext = {
+          onError: (ids) => failedIds.push(...ids),
+        }
+        await resolved.instance.process(batch, ctx)
+      }
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : ''
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.error(
+        `Error processing changes for table ${table} in ${resolved.instance.constructor.name}: ${message}`,
+        stack
+      )
+      failedIds.push(...changeIds)
+    } finally {
+      this.semaphore.release()
     }
   }
 }

--- a/libs/pg-pubsub/src/lib/services/message-processor.service.ts
+++ b/libs/pg-pubsub/src/lib/services/message-processor.service.ts
@@ -1,6 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { Inject, Injectable, Logger } from '@nestjs/common'
 import {
   ListenerDiscovery,
+  PG_PUBSUB_CONFIG,
+  PG_PUBSUB_DRAIN_INTERVAL,
+  PgPubSubConfig,
   PgTableChangeListener,
   PgTableChangePayload,
   PgTableChanges,
@@ -21,7 +24,15 @@ export class MessageProcessorService {
   /** Whether a new pull has been requested while a cycle was in progress. */
   private pendingPull = false
 
-  constructor(private readonly queueService: QueueService) {}
+  /** Delay between drain loop iterations in milliseconds. */
+  private readonly drainInterval: number
+
+  constructor(
+    private readonly queueService: QueueService,
+    @Inject(PG_PUBSUB_CONFIG) config: PgPubSubConfig
+  ) {
+    this.drainInterval = config.queue?.drainInterval ?? PG_PUBSUB_DRAIN_INTERVAL
+  }
 
   /**
    * Pull pending messages from the queue and process them.
@@ -51,84 +62,92 @@ export class MessageProcessorService {
 
   private async doPullAndProcess(channel: string, discoveryResult: ListenerDiscovery): Promise<void> {
     try {
-      const messages = await this.queueService.fetchPendingMessages(channel)
+      let messages = await this.queueService.fetchPendingMessages(channel)
 
-      if (messages.length === 0) return
+      while (messages.length > 0) {
+        this.logger.log(`Processing ${messages.length} messages from queue for channel ${channel}`)
 
-      this.logger.log(`Processing ${messages.length} messages from queue for channel ${channel}`)
+        // Process each message
+        const payloads: PgTableChangePayload[] = []
+        for (const message of messages) {
+          try {
+            const payload = message.payload as PgTableChangePayload<unknown>
+            payload.id = message.id
+            payload._metadata = {
+              retry_count: message.retry_count,
+              created_at: message.created_at,
+            }
 
-      // Process each message
-      const payloads: PgTableChangePayload[] = []
-      for (const message of messages) {
-        try {
-          const payload = message.payload as PgTableChangePayload<unknown>
-          payload.id = message.id
-          payload._metadata = {
-            retry_count: message.retry_count,
-            created_at: message.created_at,
-          }
-
-          switch (payload.event) {
-            case 'INSERT':
-              {
-                const insert = payload as PgTableInsertPayload<unknown>
-                insert.data = createEntity(
-                  insert.table,
-                  insert.data,
-                  discoveryResult.tablesMap,
-                  discoveryResult.columnNameToPropNames
-                )
-                payloads.push(insert)
-              }
-              break
-            case 'UPDATE':
-              {
-                const update = payload as PgTableUpdatePayload<unknown>
-                const oldData = createEntity(
-                  update.table,
-                  update.data.old,
-                  discoveryResult.tablesMap,
-                  discoveryResult.columnNameToPropNames
-                )
-                const newData = createEntity(
-                  update.table,
-                  update.data.new,
-                  discoveryResult.tablesMap,
-                  discoveryResult.columnNameToPropNames
-                )
-
-                update.data = {
-                  new: newData,
-                  old: oldData,
-                  updatedFields: Object.keys(oldData as Record<string, unknown>).filter(
-                    (key) => typeof oldData[key] !== 'object' && oldData[key] !== newData[key]
-                  ),
+            switch (payload.event) {
+              case 'INSERT':
+                {
+                  const insert = payload as PgTableInsertPayload<unknown>
+                  insert.data = createEntity(
+                    insert.table,
+                    insert.data,
+                    discoveryResult.tablesMap,
+                    discoveryResult.columnNameToPropNames
+                  )
+                  payloads.push(insert)
                 }
+                break
+              case 'UPDATE':
+                {
+                  const update = payload as PgTableUpdatePayload<unknown>
+                  const oldData = createEntity(
+                    update.table,
+                    update.data.old,
+                    discoveryResult.tablesMap,
+                    discoveryResult.columnNameToPropNames
+                  )
+                  const newData = createEntity(
+                    update.table,
+                    update.data.new,
+                    discoveryResult.tablesMap,
+                    discoveryResult.columnNameToPropNames
+                  )
 
-                payloads.push(update)
-              }
-              break
-            case 'DELETE':
-              {
-                const deletion = payload as PgTableDeletePayload<unknown>
-                deletion.data = createEntity(
-                  deletion.table,
-                  deletion.data,
-                  discoveryResult.tablesMap,
-                  discoveryResult.columnNameToPropNames
-                )
+                  update.data = {
+                    new: newData,
+                    old: oldData,
+                    updatedFields: Object.keys(oldData as Record<string, unknown>).filter(
+                      (key) => typeof oldData[key] !== 'object' && oldData[key] !== newData[key]
+                    ),
+                  }
 
-                payloads.push(deletion)
-              }
-              break
+                  payloads.push(update)
+                }
+                break
+              case 'DELETE':
+                {
+                  const deletion = payload as PgTableDeletePayload<unknown>
+                  deletion.data = createEntity(
+                    deletion.table,
+                    deletion.data,
+                    discoveryResult.tablesMap,
+                    discoveryResult.columnNameToPropNames
+                  )
+
+                  payloads.push(deletion)
+                }
+                break
+            }
+          } catch (error) {
+            this.logger.error(`Error processing message ${message.id}:`, error)
+            await this.queueService.markAsFailed([message.id])
           }
-        } catch (error) {
-          this.logger.error(`Error processing message ${message.id}:`, error)
-          await this.queueService.markAsFailed([message.id])
         }
-      }
 
-      await this.processChanges(payloads, discoveryResult.listenersMap)
+        const startTime = Date.now()
+        await this.processChanges(payloads, discoveryResult.listenersMap)
+        this.logger.log(`Batch processed in ${Date.now() - startTime}ms`)
+
+        if (this.drainInterval > 0) {
+          await new Promise((resolve) => setTimeout(resolve, this.drainInterval))
+        }
+
+        messages = await this.queueService.fetchPendingMessages(channel)
+      }
     } catch (error) {
       this.logger.error('Error pulling messages:', error)
     }
@@ -157,6 +176,11 @@ export class MessageProcessorService {
     const promises: Promise<void>[] = []
     const failedIds: number[] = []
 
+    const tableBreakdown = Object.entries(groupByTables)
+      .map(([table, changes]) => `${table}(${changes.length})`)
+      .join(', ')
+    this.logger.log(`Processing changes: ${tableBreakdown}`)
+
     for (const [table, changes] of Object.entries(groupByTables)) {
       const listeners = listenersMap[table] ?? []
 
@@ -164,7 +188,10 @@ export class MessageProcessorService {
       const updates = changes.filter((c) => c.event === 'UPDATE') as PgTableUpdatePayload<T>[]
       const deletes = changes.filter((c) => c.event === 'DELETE') as PgTableDeletePayload<T>[]
 
+      const changeIds = changes.map((c) => c.id)
+
       listeners.forEach((listener) => {
+        this.logger.debug(`Routing ${changes.length} changes to ${listener.constructor.name} for table ${table}`)
         promises.push(
           listener
             .process(
@@ -177,7 +204,8 @@ export class MessageProcessorService {
               (ids) => failedIds.push(...ids)
             )
             .catch((error) => {
-              this.logger.error(`Error processing changes for table ${table}:`, error)
+              this.logger.error(`Error processing changes for table ${table} in ${listener.constructor.name}:`, error)
+              failedIds.push(...changeIds)
             })
         )
       })

--- a/libs/pg-pubsub/src/lib/services/pg-connection-pool.service.ts
+++ b/libs/pg-pubsub/src/lib/services/pg-connection-pool.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import { Pool, PoolClient, PoolConfig } from 'pg'
-import { PG_PUBSUB_CONFIG, PgPubSubConfig } from '../pg-pubsub'
+import { PG_PUBSUB_CONFIG, PG_PUBSUB_POOL_MAX, PgPubSubConfig } from '../pg-pubsub'
 
 /**
  * Dedicated PostgreSQL connection pool for pg-pubsub operations,
@@ -17,7 +17,7 @@ export class PgConnectionPoolService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   async onModuleInit(): Promise<void> {
-    const maxPoolSize = this.config.pool?.max ?? 2
+    const maxPoolSize = this.config.pool?.max ?? PG_PUBSUB_POOL_MAX
     if (!Number.isInteger(maxPoolSize) || maxPoolSize < 1) {
       throw new Error(`Invalid pg-pubsub pool.max value: ${maxPoolSize}. Must be a positive integer.`)
     }

--- a/libs/pg-pubsub/src/lib/services/queue.service.spec.ts
+++ b/libs/pg-pubsub/src/lib/services/queue.service.spec.ts
@@ -60,7 +60,7 @@ describe('QueueService', () => {
   })
 
   describe('startWorker', () => {
-    it('should recover orphans, run initial cleanup, and start periodic cleanup', async () => {
+    it('should recover orphans, run cleanup, and start periodic cleanup', async () => {
       const cleanupSpy = jest.spyOn(queueService as any, 'cleanupOldMessages').mockResolvedValue(undefined)
       const recoverSpy = jest.spyOn(queueService as any, 'recoverOrphanedMessages').mockResolvedValue(undefined)
       const startPeriodicCleanupSpy = jest.spyOn(queueService as any, 'startPeriodicCleanup')
@@ -128,38 +128,32 @@ describe('QueueService', () => {
   })
 
   describe('cleanupOldMessages', () => {
-    it('should delete processed messages older than TTL', async () => {
+    it('should delete terminal messages older than TTL', async () => {
       pgPool.query.mockResolvedValueOnce([{ id: 1 }, { id: 2 }])
 
       await (queueService as any).cleanupOldMessages()
 
-      expect(pgPool.query).toHaveBeenCalledWith(
-        expect.stringContaining(`DELETE FROM "${config.queue.schema}"."${config.queue.table}"`),
-        expect.any(Array)
-      )
-    })
-
-    it('should also delete stale processing messages older than TTL', async () => {
-      pgPool.query.mockResolvedValueOnce([{ id: 3 }])
-
-      await (queueService as any).cleanupOldMessages()
-
       const query = pgPool.query.mock.calls[0][0]
-      expect(query).toContain(`status = 'processing'`)
+      expect(query).toContain(`DELETE FROM "${config.queue.schema}"."${config.queue.table}"`)
+      expect(query).toContain(`status = 'processed' AND processed_at < $1`)
+      expect(query).toContain(`status = 'failed' AND retry_count >= $2 AND created_at < $1`)
+      expect(query).toContain(`status = 'processing' AND created_at < $1`)
+      expect(pgPool.query).toHaveBeenCalledWith(query, [expect.any(Date), config.queue.maxRetries])
     })
   })
 
   describe('recoverOrphanedMessages', () => {
-    it('should reset processing messages back to pending only when next_retry_at has passed', async () => {
+    it('should reset recent processing messages back to pending only when next_retry_at has passed', async () => {
       pgPool.query.mockResolvedValueOnce([{ id: 1 }, { id: 2 }, { id: 3 }])
 
       await queueService['recoverOrphanedMessages']()
 
-      expect(pgPool.query).toHaveBeenCalledWith(expect.stringContaining(`SET status = 'pending'`))
-      expect(pgPool.query).toHaveBeenCalledWith(expect.stringContaining(`WHERE status = 'processing'`))
-      expect(pgPool.query).toHaveBeenCalledWith(
-        expect.stringContaining(`next_retry_at IS NULL OR next_retry_at <= NOW()`)
-      )
+      const query = pgPool.query.mock.calls[0][0]
+      expect(query).toContain(`SET status = 'pending'`)
+      expect(query).toContain(`WHERE status = 'processing'`)
+      expect(query).toContain(`next_retry_at IS NULL OR next_retry_at <= NOW()`)
+      expect(query).toContain(`created_at >= $1`)
+      expect(pgPool.query).toHaveBeenCalledWith(query, [expect.any(Date)])
     })
 
     it('should do nothing when no orphaned messages exist', async () => {

--- a/libs/pg-pubsub/src/lib/services/queue.service.spec.ts
+++ b/libs/pg-pubsub/src/lib/services/queue.service.spec.ts
@@ -19,6 +19,7 @@ describe('QueueService', () => {
       messageTTL: 3600000,
       cleanupInterval: 60000,
       batchSize: 100,
+      processingTimeout: 300000,
     },
   }
 
@@ -48,14 +49,27 @@ describe('QueueService', () => {
     jest.clearAllMocks()
   })
 
-  describe('setup', () => {
-    it('should create queue table and start cleanup', async () => {
-      const startCleanupSpy = jest.spyOn(queueService as any, 'startCleanup')
+  describe('ensureQueueTable', () => {
+    it('should create queue table and indexes', async () => {
+      await queueService.ensureQueueTable()
 
-      await queueService.setup()
+      expect(pgPool.query).toHaveBeenCalledWith(
+        expect.stringContaining(`CREATE TABLE IF NOT EXISTS "${config.queue.schema}"."${config.queue.table}"`)
+      )
+    })
+  })
 
-      expect(pgPool.query).toHaveBeenCalled()
-      expect(startCleanupSpy).toHaveBeenCalled()
+  describe('startWorker', () => {
+    it('should recover orphans, run initial cleanup, and start periodic cleanup', async () => {
+      const cleanupSpy = jest.spyOn(queueService as any, 'cleanupOldMessages').mockResolvedValue(undefined)
+      const recoverSpy = jest.spyOn(queueService as any, 'recoverOrphanedMessages').mockResolvedValue(undefined)
+      const startPeriodicCleanupSpy = jest.spyOn(queueService as any, 'startPeriodicCleanup')
+
+      await queueService.startWorker()
+
+      expect(recoverSpy).toHaveBeenCalled()
+      expect(cleanupSpy).toHaveBeenCalled()
+      expect(startPeriodicCleanupSpy).toHaveBeenCalled()
     })
   })
 
@@ -68,7 +82,7 @@ describe('QueueService', () => {
 
       expect(pgPool.query).toHaveBeenCalledWith(
         expect.stringContaining(`UPDATE "${config.queue.schema}"."${config.queue.table}"`),
-        [config.queue.maxRetries, 'test_channel', config.queue.batchSize]
+        [config.queue.maxRetries, 'test_channel', config.queue.batchSize, 300000]
       )
       expect(result).toEqual(mockMessages)
     })
@@ -123,6 +137,44 @@ describe('QueueService', () => {
         expect.stringContaining(`DELETE FROM "${config.queue.schema}"."${config.queue.table}"`),
         expect.any(Array)
       )
+    })
+
+    it('should also delete stale processing messages older than TTL', async () => {
+      pgPool.query.mockResolvedValueOnce([{ id: 3 }])
+
+      await (queueService as any).cleanupOldMessages()
+
+      const query = pgPool.query.mock.calls[0][0]
+      expect(query).toContain(`status = 'processing'`)
+    })
+  })
+
+  describe('recoverOrphanedMessages', () => {
+    it('should reset processing messages back to pending only when next_retry_at has passed', async () => {
+      pgPool.query.mockResolvedValueOnce([{ id: 1 }, { id: 2 }, { id: 3 }])
+
+      await queueService['recoverOrphanedMessages']()
+
+      expect(pgPool.query).toHaveBeenCalledWith(expect.stringContaining(`SET status = 'pending'`))
+      expect(pgPool.query).toHaveBeenCalledWith(expect.stringContaining(`WHERE status = 'processing'`))
+      expect(pgPool.query).toHaveBeenCalledWith(
+        expect.stringContaining(`next_retry_at IS NULL OR next_retry_at <= NOW()`)
+      )
+    })
+
+    it('should do nothing when no orphaned messages exist', async () => {
+      pgPool.query.mockResolvedValueOnce([])
+
+      await queueService['recoverOrphanedMessages']()
+
+      expect(pgPool.query).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw error on database failure', async () => {
+      const error = new Error('Database error')
+      pgPool.query.mockRejectedValue(error)
+
+      await expect(queueService['recoverOrphanedMessages']()).rejects.toThrow(error)
     })
   })
 })

--- a/libs/pg-pubsub/src/lib/services/queue.service.ts
+++ b/libs/pg-pubsub/src/lib/services/queue.service.ts
@@ -8,6 +8,7 @@ import {
   PG_PUBSUB_QUEUE_CLEANUP_INTERVAL,
   PG_PUBSUB_QUEUE_MAX_RETRIES,
   PG_PUBSUB_QUEUE_MESSAGE_TTL,
+  PG_PUBSUB_QUEUE_PROCESSING_TIMEOUT,
   PG_PUBSUB_QUEUE_SCHEMA,
   PG_PUBSUB_QUEUE_TABLE,
   PgPubSubConfig,
@@ -17,14 +18,15 @@ import { PgConnectionPoolService } from './pg-connection-pool.service'
 
 @Injectable()
 export class QueueService {
-  private readonly logger = new Logger(QueueService.name)
   private cleanupSubscription?: Subscription
+  private readonly logger = new Logger(QueueService.name)
   private readonly queueSchema: string
   private readonly queueTable: string
   private readonly maxRetries: number
   private readonly messageTTL: number
-  private readonly cleanupInterval: number
   private readonly batchSize: number
+  private readonly cleanupInterval: number
+  private readonly processingTimeout: number
 
   constructor(
     private readonly pgPool: PgConnectionPoolService,
@@ -36,14 +38,44 @@ export class QueueService {
     this.messageTTL = config.queue?.messageTTL ?? PG_PUBSUB_QUEUE_MESSAGE_TTL
     this.cleanupInterval = config.queue?.cleanupInterval ?? PG_PUBSUB_QUEUE_CLEANUP_INTERVAL
     this.batchSize = config.queue?.batchSize ?? PG_PUBSUB_QUEUE_BATCH_SIZE
+    this.processingTimeout = config.queue?.processingTimeout ?? PG_PUBSUB_QUEUE_PROCESSING_TIMEOUT
   }
 
-  async setup(): Promise<void> {
-    await this.createQueueTable()
-    this.startCleanup()
+  async ensureQueueTable(): Promise<void> {
+    try {
+      await this.pgPool.query(`
+        CREATE TABLE IF NOT EXISTS "${this.queueSchema}"."${this.queueTable}" (
+          id BIGSERIAL PRIMARY KEY,
+          channel VARCHAR(255) NOT NULL,
+          payload JSONB NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          processed_at TIMESTAMP DEFAULT NULL,
+          retry_count INT DEFAULT 0,
+          next_retry_at TIMESTAMP DEFAULT NULL,
+          status VARCHAR(20) DEFAULT '${MessageStatus.PENDING}'
+        );
+
+        CREATE INDEX IF NOT EXISTS "${this.queueTable}_status_idx"
+          ON "${this.queueSchema}"."${this.queueTable}"(status);
+        CREATE INDEX IF NOT EXISTS "${this.queueTable}_channel_idx"
+          ON "${this.queueSchema}"."${this.queueTable}"(channel);
+        CREATE INDEX IF NOT EXISTS "${this.queueTable}_next_retry_idx"
+          ON "${this.queueSchema}"."${this.queueTable}"(next_retry_at);
+      `)
+      this.logger.log(`Queue table "${this.queueSchema}"."${this.queueTable}" created or already exists`)
+    } catch (error: any) {
+      this.logger.error(`Failed to create queue table: ${error.message}`, error.stack)
+      throw error
+    }
   }
 
-  async teardown(): Promise<void> {
+  async startWorker(): Promise<void> {
+    await this.recoverOrphanedMessages()
+    await this.cleanupOldMessages()
+    this.startPeriodicCleanup()
+  }
+
+  async stopWorker(): Promise<void> {
     if (this.cleanupSubscription) {
       this.cleanupSubscription.unsubscribe()
     }
@@ -55,7 +87,7 @@ export class QueueService {
         `
         UPDATE "${this.queueSchema}"."${this.queueTable}"
         SET status = '${MessageStatus.PROCESSING}',
-            next_retry_at = NOW() + interval '5 minutes'
+            next_retry_at = NOW() + ($4 || ' milliseconds')::interval
         WHERE id IN (
           SELECT id FROM "${this.queueSchema}"."${this.queueTable}"
           WHERE (status = '${MessageStatus.PENDING}' OR
@@ -69,7 +101,7 @@ export class QueueService {
         )
         RETURNING *
       `,
-        [this.maxRetries, channel, this.batchSize]
+        [this.maxRetries, channel, this.batchSize, this.processingTimeout]
       )
 
       return messages || []
@@ -117,35 +149,7 @@ export class QueueService {
     }
   }
 
-  private async createQueueTable(): Promise<void> {
-    try {
-      await this.pgPool.query(`
-        CREATE TABLE IF NOT EXISTS "${this.queueSchema}"."${this.queueTable}" (
-          id BIGSERIAL PRIMARY KEY,
-          channel VARCHAR(255) NOT NULL,
-          payload JSONB NOT NULL,
-          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-          processed_at TIMESTAMP DEFAULT NULL,
-          retry_count INT DEFAULT 0,
-          next_retry_at TIMESTAMP DEFAULT NULL,
-          status VARCHAR(20) DEFAULT '${MessageStatus.PENDING}'
-        );
-
-        CREATE INDEX IF NOT EXISTS "${this.queueTable}_status_idx"
-          ON "${this.queueSchema}"."${this.queueTable}"(status);
-        CREATE INDEX IF NOT EXISTS "${this.queueTable}_channel_idx"
-          ON "${this.queueSchema}"."${this.queueTable}"(channel);
-        CREATE INDEX IF NOT EXISTS "${this.queueTable}_next_retry_idx"
-          ON "${this.queueSchema}"."${this.queueTable}"(next_retry_at);
-      `)
-      this.logger.log(`Queue table "${this.queueSchema}"."${this.queueTable}" created or already exists`)
-    } catch (error: any) {
-      this.logger.error(`Failed to create queue table: ${error.message}`, error.stack)
-      throw error
-    }
-  }
-
-  private startCleanup(): void {
+  private startPeriodicCleanup(): void {
     this.cleanupSubscription = interval(this.cleanupInterval).subscribe(() => {
       this.cleanupOldMessages().catch((err) => {
         this.logger.error('Failed to clean up old messages', err)
@@ -155,27 +159,60 @@ export class QueueService {
 
   private async cleanupOldMessages(): Promise<void> {
     const cutoffDate = new Date(Date.now() - this.messageTTL)
+    let totalCleaned = 0
 
     try {
-      const result = await this.pgPool.query(
-        `
+      let deleted: { id: number }[]
+      do {
+        deleted = await this.pgPool.query<{ id: number }>(
+          `
         DELETE FROM "${this.queueSchema}"."${this.queueTable}"
         WHERE id IN (
           SELECT id FROM "${this.queueSchema}"."${this.queueTable}"
           WHERE (status = '${MessageStatus.PROCESSED}' AND processed_at < $1)
             OR (created_at < $1 AND status = '${MessageStatus.FAILED}' AND retry_count >= $2)
+            OR (created_at < $1 AND status = '${MessageStatus.PROCESSING}')
           LIMIT 1000
         )
         RETURNING id
       `,
-        [cutoffDate, this.maxRetries]
-      )
+          [cutoffDate, this.maxRetries]
+        )
+        totalCleaned += deleted?.length ?? 0
+      } while (deleted?.length === 1000)
 
-      if (result?.length) {
-        this.logger.log(`Cleaned up ${result.length} old messages`)
+      if (totalCleaned > 0) {
+        this.logger.log(`Cleaned up ${totalCleaned} old messages`)
       }
     } catch (error: any) {
       this.logger.error(`Failed to clean up old messages: ${error.message}`, error.stack)
+      throw error
+    }
+  }
+
+  /**
+   * Reset orphaned messages (stuck in 'processing' due to instance crash) back to 'pending'
+   * so they can be retried. Only recovers messages whose next_retry_at has passed,
+   * to avoid resetting messages actively being processed by another instance.
+   */
+  private async recoverOrphanedMessages(): Promise<void> {
+    try {
+      const result = await this.pgPool.query(
+        `
+        UPDATE "${this.queueSchema}"."${this.queueTable}"
+        SET status = '${MessageStatus.PENDING}',
+            next_retry_at = NULL
+        WHERE status = '${MessageStatus.PROCESSING}'
+          AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+        RETURNING id
+      `
+      )
+
+      if (result?.length) {
+        this.logger.log(`Recovered ${result.length} orphaned messages back to pending`)
+      }
+    } catch (error: any) {
+      this.logger.error(`Failed to recover orphaned messages: ${error.message}`, error.stack)
       throw error
     }
   }

--- a/libs/pg-pubsub/src/lib/services/queue.service.ts
+++ b/libs/pg-pubsub/src/lib/services/queue.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { interval, Subscription } from 'rxjs'
 import {
@@ -63,8 +62,10 @@ export class QueueService {
           ON "${this.queueSchema}"."${this.queueTable}"(next_retry_at);
       `)
       this.logger.log(`Queue table "${this.queueSchema}"."${this.queueTable}" created or already exists`)
-    } catch (error: any) {
-      this.logger.error(`Failed to create queue table: ${error.message}`, error.stack)
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : ''
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.error(`Failed to create queue table: ${message}`, stack)
       throw error
     }
   }
@@ -106,7 +107,9 @@ export class QueueService {
 
       return messages || []
     } catch (error) {
-      this.logger.error(`Failed to fetch pending messages:`, error)
+      const stack = error instanceof Error ? error.stack : ''
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.error(`Failed to fetch pending messages: ${message}`, stack)
       throw error
     }
   }
@@ -123,7 +126,9 @@ export class QueueService {
         [messageIds]
       )
     } catch (error) {
-      this.logger.error(`Failed to mark message ${JSON.stringify(messageIds)} as processed:`, error)
+      const stack = error instanceof Error ? error.stack : ''
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.error(`Failed to mark message ${JSON.stringify(messageIds)} as processed: ${message}`, stack)
       throw error
     }
   }
@@ -144,7 +149,9 @@ export class QueueService {
         [this.maxRetries, messageIds]
       )
     } catch (error) {
-      this.logger.error(`Failed to mark message ${JSON.stringify(messageIds)} as failed: `, error)
+      const stack = error instanceof Error ? error.stack : ''
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.error(`Failed to mark message ${JSON.stringify(messageIds)} as failed: ${message}`, stack)
       throw error
     }
   }
@@ -152,11 +159,19 @@ export class QueueService {
   private startPeriodicCleanup(): void {
     this.cleanupSubscription = interval(this.cleanupInterval).subscribe(() => {
       this.cleanupOldMessages().catch((err) => {
-        this.logger.error('Failed to clean up old messages', err)
+        const stack = err instanceof Error ? err.stack : ''
+        const message = err instanceof Error ? err.message : String(err)
+        this.logger.error(`Failed to clean up old messages: ${message}`, stack)
       })
     })
   }
 
+  /**
+   * Deletes terminal messages older than the configured TTL in batches of 1000:
+   * - PROCESSED with processed_at older than TTL
+   * - FAILED with exhausted retries and created_at older than TTL
+   * - PROCESSING with created_at older than TTL (non-recoverable zombies)
+   */
   private async cleanupOldMessages(): Promise<void> {
     const cutoffDate = new Date(Date.now() - this.messageTTL)
     let totalCleaned = 0
@@ -166,16 +181,16 @@ export class QueueService {
       do {
         deleted = await this.pgPool.query<{ id: number }>(
           `
-        DELETE FROM "${this.queueSchema}"."${this.queueTable}"
-        WHERE id IN (
-          SELECT id FROM "${this.queueSchema}"."${this.queueTable}"
-          WHERE (status = '${MessageStatus.PROCESSED}' AND processed_at < $1)
-            OR (created_at < $1 AND status = '${MessageStatus.FAILED}' AND retry_count >= $2)
-            OR (created_at < $1 AND status = '${MessageStatus.PROCESSING}')
-          LIMIT 1000
-        )
-        RETURNING id
-      `,
+            DELETE FROM "${this.queueSchema}"."${this.queueTable}"
+            WHERE id IN (
+              SELECT id FROM "${this.queueSchema}"."${this.queueTable}"
+              WHERE (status = '${MessageStatus.PROCESSED}' AND processed_at < $1)
+                OR (status = '${MessageStatus.FAILED}' AND retry_count >= $2 AND created_at < $1)
+                OR (status = '${MessageStatus.PROCESSING}' AND created_at < $1)
+              LIMIT 1000
+            )
+            RETURNING id
+          `,
           [cutoffDate, this.maxRetries]
         )
         totalCleaned += deleted?.length ?? 0
@@ -184,19 +199,27 @@ export class QueueService {
       if (totalCleaned > 0) {
         this.logger.log(`Cleaned up ${totalCleaned} old messages`)
       }
-    } catch (error: any) {
-      this.logger.error(`Failed to clean up old messages: ${error.message}`, error.stack)
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : ''
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.error(`Failed to clean up old messages: ${message}`, stack)
       throw error
     }
   }
 
   /**
    * Reset orphaned messages (stuck in 'processing' due to instance crash) back to 'pending'
-   * so they can be retried. Only recovers messages whose next_retry_at has passed,
-   * to avoid resetting messages actively being processed by another instance.
+   * so they can be retried.
+   *
+   * Guards:
+   * - next_retry_at: only recovers messages whose processing timeout has expired,
+   *   so messages actively being processed by another instance are never touched.
+   * - created_at: messages older than the TTL are not recoverable. They will be
+   *   deleted by cleanupOldMessages() instead.
    */
   private async recoverOrphanedMessages(): Promise<void> {
     try {
+      const cutoffDate = new Date(Date.now() - this.messageTTL)
       const result = await this.pgPool.query(
         `
         UPDATE "${this.queueSchema}"."${this.queueTable}"
@@ -204,15 +227,19 @@ export class QueueService {
             next_retry_at = NULL
         WHERE status = '${MessageStatus.PROCESSING}'
           AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+          AND created_at >= $1
         RETURNING id
-      `
+      `,
+        [cutoffDate]
       )
 
       if (result?.length) {
         this.logger.log(`Recovered ${result.length} orphaned messages back to pending`)
       }
-    } catch (error: any) {
-      this.logger.error(`Failed to recover orphaned messages: ${error.message}`, error.stack)
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : ''
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.error(`Failed to recover orphaned messages: ${message}`, stack)
       throw error
     }
   }

--- a/libs/pg-pubsub/src/lib/services/semaphore.spec.ts
+++ b/libs/pg-pubsub/src/lib/services/semaphore.spec.ts
@@ -1,0 +1,52 @@
+import { Semaphore } from '../semaphore'
+
+describe('Semaphore', () => {
+  it('should allow up to max concurrent acquisitions', async () => {
+    const sem = new Semaphore(2)
+
+    await sem.acquire()
+    await sem.acquire()
+
+    let thirdAcquired = false
+    const p = sem.acquire().then(() => {
+      thirdAcquired = true
+    })
+
+    // Third acquire should be waiting
+    await new Promise((r) => setTimeout(r, 10))
+    expect(thirdAcquired).toBe(false)
+
+    sem.release()
+    await p
+    expect(thirdAcquired).toBe(true)
+
+    sem.release()
+    sem.release()
+  })
+
+  it('should process waiters in FIFO order', async () => {
+    const sem = new Semaphore(1)
+    const order: number[] = []
+
+    await sem.acquire()
+
+    const p1 = sem.acquire().then(() => order.push(1))
+    const p2 = sem.acquire().then(() => order.push(2))
+
+    sem.release()
+    await p1
+
+    sem.release()
+    await p2
+
+    expect(order).toEqual([1, 2])
+
+    sem.release()
+  })
+
+  it('should handle release without waiters', () => {
+    const sem = new Semaphore(3)
+    // Release without acquire should not throw
+    sem.release()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "release:major": "standard-version --release-as major",
     "release:minor": "standard-version --release-as minor",
     "release:patch": "standard-version --release-as patch",
-    "test:integration": "jest --config=jest.config.ts --testMatch='**/*.integration.spec.ts' --runInBand --detectOpenHandles"
+    "test:integration": "jest --config=jest.config.ts --testMatch='**/*.integration.spec.ts' --runInBand --detectOpenHandles",
+    "test:stress": "jest --config=libs/pg-pubsub/jest.config.ts --testPathIgnorePatterns='integration' --testMatch='**/*.stress.spec.ts' --runInBand --detectOpenHandles"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

Major refactor of `@cisstech/nestjs-pg-pubsub` focused on queue reliability, multi-instance safety, concurrency control, and ORM-agnostic transaction support.

## Changes

### 1. Queue reliability & multi-instance safety
- **Orphan recovery**: on startup, `PROCESSING` messages whose timeout expired are reset to `PENDING`, but only if younger than TTL (older ones are non-recoverable)
- **Cleanup hardened**: single TTL-based query deletes expired `PROCESSED`, exhausted `FAILED`, and zombie `PROCESSING` messages. Safe for multi-instance deployments
- **Batched cleanup**: deletes in batches of 1000 to avoid long-running transactions

### 2. TransactionAdapter
- New `TransactionAdapter<TToken>` interface: ORM-agnostic, the app provides a factory that wraps listener execution in a transaction
- Listeners opt-in via `@RegisterPgTableChangeListener(Entity, { transactional: true })`
- Token passed to listeners via `ctx.transaction` in the new `PgTableChangeContext`
- Boot validation: startup fails fast if transactional listeners are registered without an adapter

### 3. Concurrency control
- New `Semaphore` class for bounded parallel listener execution
- Default concurrency: 5, configurable via `queue.concurrency`
- Prevents pool exhaustion under high load

### 4. Listener signature change (BREAKING)
- `process(changes, onError?)` → `process(changes, ctx: PgTableChangeContext)`
- `ctx.onError`: error handler (non-transactional mode)
- `ctx.transaction`: opaque token (transactional mode)

### 5. Message processor improvements
- Builds `PgTableChanges` batch once, then dispatches to each listener via `executeListener`
- Each listener execution is semaphore-gated
- Transactional listeners: failure marks all message IDs as failed (transaction rolled back)
- Non-transactional listeners: `onError` allows partial failure reporting

### 6. Documentation
- README updated with new listener signature, transaction support, concurrency config
- All doc pages rewritten for clarity and accuracy

### 7. Stress tests & CI
- 4 stress test scenarios (high throughput, concurrent listeners, failure recovery, backpressure)
- CI workflow updated with stress test job

## Breaking Changes

- `PgTableChangeListener.process()` signature: `(changes, onError?)` → `(changes, ctx)`
- `ListenerDiscovery.listenersMap` returns `ResolvedListener[]` instead of `PgTableChangeListener[]`
