### PR TITLE
docs(pg-pubsub): document transaction management

### DIFF
--- a/apps/app/src/assets/docs/pg-pubsub/advanced-usage.md
+++ b/apps/app/src/assets/docs/pg-pubsub/advanced-usage.md
@@ -42,6 +42,86 @@ PgPubSubModule.forRoot({
 
 **`pool.max`**: The library uses its own `pg.Pool` for all SQL operations (queue reads, advisory locks, trigger DDL). This pool is completely independent of TypeORM's pool, ensuring pg-pubsub keeps working even when TypeORM's pool is exhausted.
 
+## Transaction Management
+
+By default, listeners run without a transaction: you handle errors granularly via `ctx.onError`. For listeners that need atomicity (e.g., writing to multiple tables), the library supports wrapping the entire listener execution in a transaction via an ORM-agnostic adapter.
+
+### 1. Provide a TransactionAdapter
+
+A `TransactionAdapter` opens a transaction, executes a callback, and commits on success or rolls back on failure. Here is a TypeORM example:
+
+```typescript
+import { TransactionAdapter } from '@cisstech/nestjs-pg-pubsub'
+import { DataSource, EntityManager } from 'typeorm'
+
+export class TypeOrmTransactionAdapter implements TransactionAdapter<EntityManager> {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async run<T>(callback: (em: EntityManager) => Promise<T>): Promise<T> {
+    return this.dataSource.transaction(callback)
+  }
+}
+```
+
+Register it in the module config:
+
+```typescript
+PgPubSubModule.forRoot({
+  databaseUrl: process.env.DATABASE_URL,
+  transactionAdapter: new TypeOrmTransactionAdapter(dataSource),
+})
+```
+
+The adapter is ORM-agnostic. `TToken` can be anything: a Prisma `$transaction` client, a Knex transaction, etc.
+
+### 2. Mark Listeners as Transactional
+
+Add `transactional: true` to the decorator options:
+
+```typescript
+@Injectable()
+@RegisterPgTableChangeListener(Order, { transactional: true })
+export class OrderChangeListener implements PgTableChangeListener<Order, EntityManager> {
+  async process(changes: PgTableChanges<Order>, ctx: PgTableChangeContext<EntityManager>): Promise<void> {
+    const em = ctx.transaction! // EntityManager bound to the active transaction
+
+    for (const insert of changes.INSERT) {
+      await em.getRepository(AuditLog).save({
+        action: 'ORDER_CREATED',
+        orderId: insert.data.id,
+      })
+    }
+  }
+}
+```
+
+### How It Works
+
+- The library calls `transactionAdapter.run()` around your `process()` method
+- `ctx.transaction` receives the opaque token (e.g., `EntityManager`) from the adapter
+- On success, the transaction commits and messages are marked as processed
+- On failure (thrown error), the transaction rolls back and **all** message IDs in the batch are marked as failed for retry
+- `ctx.onError` is a no-op in transactional mode. To signal failure, throw an exception instead
+
+### Boot Validation
+
+If any listener has `transactional: true` but no `transactionAdapter` is provided in the config, the application fails to start with a clear error message. This prevents silent misconfiguration.
+
+### Concurrency
+
+Listener executions are bounded by a semaphore (default: 5 concurrent). Configure it with `queue.concurrency`:
+
+```typescript
+PgPubSubModule.forRoot({
+  databaseUrl: process.env.DATABASE_URL,
+  queue: {
+    concurrency: 10, // max parallel listener executions
+  },
+})
+```
+
+This applies to both transactional and non-transactional listeners.
+
 ## Controlling the Listener at Runtime
 
 ### Pause / Resume

--- a/apps/app/src/assets/docs/pg-pubsub/getting-started.md
+++ b/apps/app/src/assets/docs/pg-pubsub/getting-started.md
@@ -39,7 +39,8 @@ The result: you get real-time reactivity (via `LISTEN/NOTIFY`) with guaranteed d
 
 ### Important Constraints
 
-- **Do not open transactions inside listeners.** The listener runs inside the drain loop. A slow transaction blocks processing and can cause the `processingTimeout` to expire, leading to orphan recovery and duplicate processing.
+- **Avoid long-running work in listeners.** The listener runs inside the drain loop. A slow handler blocks processing and can cause the `processingTimeout` to expire, leading to orphan recovery and duplicate processing.
+- **Use transactional listeners for multi-table writes.** If your listener needs to write to several tables atomically, mark it as `transactional: true` and provide a `transactionAdapter` in the module config. See [Advanced Usage > Transaction Management](./advanced-usage#transaction-management).
 - **Keep listeners fast.** If you need heavy work, enqueue to an external job queue (Bull, etc.) from the listener.
 
 ## Prerequisites

--- a/apps/app/src/assets/docs/pg-pubsub/sample-application.md
+++ b/apps/app/src/assets/docs/pg-pubsub/sample-application.md
@@ -64,7 +64,7 @@ The key piece is `NotificationChangeListener`:
 export class NotificationChangeListener implements PgTableChangeListener<Notification> {
   constructor(private readonly websocketGateway: WebsocketGateway) {}
 
-  async process(changes: PgTableChanges<Notification>): Promise<void> {
+  async process(changes: PgTableChanges<Notification>, ctx: PgTableChangeContext): Promise<void> {
     for (const insert of changes.INSERT) {
       this.websocketGateway.notifyUser(insert.data.userId, 'new-notification', {
         id: insert.data.id,

--- a/apps/app/src/assets/docs/pg-pubsub/usage.md
+++ b/apps/app/src/assets/docs/pg-pubsub/usage.md
@@ -32,7 +32,7 @@ Decorate a class with `@RegisterPgTableChangeListener` and implement `PgTableCha
 @Injectable()
 @RegisterPgTableChangeListener(User)
 export class UserChangeListener implements PgTableChangeListener<User> {
-  async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
+  async process(changes: PgTableChanges<User>, ctx: PgTableChangeContext): Promise<void> {
     for (const insert of changes.INSERT) {
       console.log(`New user: ${insert.data.email}`)
     }
@@ -60,21 +60,21 @@ export class UserChangeListener implements PgTableChangeListener<User> {
 
 ### Error Handling
 
-Use `onError` to mark specific messages as failed. They will be retried with exponential backoff.
+Use `ctx.onError` to mark specific messages as failed. They will be retried with exponential backoff.
 
 ```typescript
-async process(changes: PgTableChanges<User>, onError?: PgTableChangeErrorHandler): Promise<void> {
+async process(changes: PgTableChanges<User>, ctx: PgTableChangeContext): Promise<void> {
   for (const change of changes.all) {
     try {
       await this.doSomething(change)
     } catch {
-      onError?.([change.id])  // this message will be retried
+      ctx.onError([change.id])  // this message will be retried
     }
   }
 }
 ```
 
-If the entire `process()` method throws without calling `onError`, all messages in the batch are marked as failed.
+If the entire `process()` method throws without calling `ctx.onError`, all messages in the batch are marked as failed.
 
 ### Retry Metadata
 


### PR DESCRIPTION
## Summary

Document the new transaction management feature and update all doc pages to reflect the new listener signature.

## Changes

- **advanced-usage.md**: New "Transaction Management" section covering `TransactionAdapter`, transactional listeners, boot validation, and concurrency control
- **usage.md**: Updated listener signature from `(changes, onError?)` to `(changes, ctx: PgTableChangeContext)` and error handling examples
- **getting-started.md**: Updated constraints section to reference transactional listeners instead of blanket "no transactions" warning
- **sample-application.md**: Updated sample listener to use the new `ctx` signature

## Context

Follows up on #58 which added `TransactionAdapter`, `Semaphore` concurrency, and hardened queue cleanup but did not document the transaction feature in the doc pages.