### PR TITLE
ci: bump codecov-action to v7 to drop the node 20 github-script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
codecov-action v4 runs on node20 and v5 calls github-script@v7 (node20); v7 uses github-script@v8 (node24), clearing the last runtime deprecation warning.