### PR TITLE
fix(app): unbreak the gh-pages deploy

### DIFF
--- a/apps/app/project.json
+++ b/apps/app/project.json
@@ -114,7 +114,7 @@
         "commands": [
           "nx build app --configuration production",
           "bash scripts/stage-ghpages.sh dist/apps/app/browser",
-          "angular-cli-ghpages --dir=dist/apps/app/browser --repo=https://github.com/cisstech/nestkit.git"
+          "npx angular-cli-ghpages --dir=dist/apps/app/browser --repo=https://github.com/cisstech/nestkit.git"
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:api": "nx run api:build --prod",
     "build:app": "nx run app:build --prod",
     "build:libs": "nx run-many --target=build --exclude=api,app --configuration=production",
-    "publish:app": "nx run app:deploy --no-silent",
+    "publish:app": "nx run app:deploy",
     "test": "nx run-many --target=test --parallel=false --runInBand --detectOpenHandles --all --coverage=true --coverageReporters=lcov --watch=false --browsers=ChromeHeadless && node coverage-merger.js",
     "lint": "nx report && nx run-many --target=lint --all",
     "lint:fix": "nx report && nx run-many --target=lint --all --fix",


### PR DESCRIPTION
The `Publish Gh Pages` workflow failed after #83 merged.

`publish:app` ran `nx run app:deploy --no-silent`. The new `run-commands` deploy forwards `--no-silent` into the nested `nx build`, which fails on the unknown flag (fast 183ms fail on `app:build:production`). The flag was only meaningful to the previous `angular-cli-ghpages` executor.

Dropping it so the `build → stage → publish` chain runs. Auth and the rest of the chain are unchanged (`GITHUB_TOKEN` is already provided by the workflow).