### PR TITLE
chore(app): bump @cisstech/nge to 22.4.3

### DIFF
--- a/apps/app/src/app/app.config.ts
+++ b/apps/app/src/app/app.config.ts
@@ -14,10 +14,10 @@ import {
   withIcons,
   withKatex,
   withLinkAnchor,
-  withShiki,
   withTabbedSet,
   withThemes,
 } from '@cisstech/nge/markdown'
+import { withShiki } from '@cisstech/nge/markdown/shiki'
 
 export function markdownOptions(): NgeMarkdownConfig {
   return {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@angular/platform-browser": "22.0.6",
     "@angular/platform-browser-dynamic": "22.0.6",
     "@angular/router": "22.0.6",
-    "@cisstech/nge": "^22.4.2",
+    "@cisstech/nge": "^22.4.3",
     "@golevelup/nestjs-discovery": "^5.0.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3873,9 +3873,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cisstech/nge@npm:^22.4.2":
-  version: 22.4.2
-  resolution: "@cisstech/nge@npm:22.4.2"
+"@cisstech/nge@npm:^22.4.3":
+  version: 22.4.3
+  resolution: "@cisstech/nge@npm:22.4.3"
   dependencies:
     marked: "npm:^11.0.1"
     tslib: "npm:^2.3.0"
@@ -3903,7 +3903,7 @@ __metadata:
       optional: true
     typedoc:
       optional: true
-  checksum: 10c0/d379de7947b855e15b08f6a3cd4aa70326e8c1970ecc723b2b3190b5b902960099197c8bf8bcbba65bcf427ee620df9d1a572fdf59ba8f425ecc902a8da0244e
+  checksum: 10c0/24dcb33a622e22a0962f630a279695d306b0e83f3d7d95afb7f58afd16833fb4029501306ac3fee37609ba4cabf3509507e775c12c934c8fff333ad64d88b726
   languageName: node
   linkType: hard
 
@@ -21073,7 +21073,7 @@ __metadata:
     "@angular/platform-server": "npm:^22.0.0"
     "@angular/router": "npm:22.0.6"
     "@angular/ssr": "npm:^22.0.0"
-    "@cisstech/nge": "npm:^22.4.2"
+    "@cisstech/nge": "npm:^22.4.3"
     "@commitlint/cli": "npm:^18.4.3"
     "@commitlint/config-conventional": "npm:^18.4.3"
     "@eslint/eslintrc": "npm:^3.0.0"


### PR DESCRIPTION
Bumps @cisstech/nge to 22.4.3 and moves the `withShiki` import to its new entry point `@cisstech/nge/markdown/shiki`. Build, prerender (80 routes), lint and format all pass.